### PR TITLE
Fixing squid: S1192 String literals should not be duplicated part 1

### DIFF
--- a/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/FactoryResetRequestHandler.java
+++ b/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/FactoryResetRequestHandler.java
@@ -39,6 +39,8 @@ import com.ibm.iotf.util.LoggerUtility;
  */	
 public class FactoryResetRequestHandler extends DMRequestHandler implements PropertyChangeListener {
 
+	private static final String REQ_ID = "reqId";
+	
 	private JsonElement reqId;
 
 	public FactoryResetRequestHandler(ManagedClient dmClient) {
@@ -65,7 +67,7 @@ public class FactoryResetRequestHandler extends DMRequestHandler implements Prop
 		DeviceAction action = getDMClient().getDeviceData().getDeviceAction();
 		if (action == null || getDMClient().getActionHandler() == null) {
 			JsonObject response = new JsonObject();
-			response.add("reqId", jsonRequest.get("reqId"));
+			response.add(REQ_ID, jsonRequest.get(REQ_ID));
 			response.add("rc", new JsonPrimitive(ResponseCode.DM_FUNCTION_NOT_IMPLEMENTED.getCode()));
 			respond(response);
 		} else {
@@ -73,7 +75,7 @@ public class FactoryResetRequestHandler extends DMRequestHandler implements Prop
 			// remove any other listener that are listening for the status update
 			((ConcreteDeviceAction)action).clearListener();
 			((ConcreteDeviceAction)action).addPropertyChangeListener(this);
-			this.reqId = jsonRequest.get("reqId");
+			this.reqId = jsonRequest.get(REQ_ID);
 			DeviceActionHandler handler = getDMClient().getActionHandler();
 			handler.handleFactoryReset(action);
 		} 
@@ -85,7 +87,7 @@ public class FactoryResetRequestHandler extends DMRequestHandler implements Prop
 			try {
 				ConcreteDeviceAction action = (ConcreteDeviceAction) evt.getNewValue();
 				JsonObject response = action.toJsonObject();
-				response.add("reqId", reqId);
+				response.add(REQ_ID, reqId);
 				respond(response);
 			} catch(Exception e) {
 				LoggerUtility.warn(CLASS_NAME, "propertyChange", e.getMessage());

--- a/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/ObserveRequestHandler.java
+++ b/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/ObserveRequestHandler.java
@@ -43,6 +43,9 @@ import com.ibm.iotf.util.LoggerUtility;
  */
 public class ObserveRequestHandler extends DMRequestHandler implements PropertyChangeListener {
 
+	private static final String FIELDS = "fields";
+	private static final String FIELD = "field";
+	
 	private ConcurrentHashMap<String, Resource> fieldsMap = new ConcurrentHashMap<String, Resource>();
 	private ConcurrentHashMap<String, JsonElement> responseMap = new ConcurrentHashMap<String, JsonElement>();
 	
@@ -67,17 +70,17 @@ public class ObserveRequestHandler extends DMRequestHandler implements PropertyC
 		JsonObject response = new JsonObject();
 		JsonArray responseArray = new JsonArray();
 		JsonObject d = (JsonObject) jsonRequest.get("d");
-		JsonArray fields = (JsonArray) d.get("fields");
+		JsonArray fields = (JsonArray) d.get(FIELDS);
 		for (int i=0; i < fields.size(); i++) {
 			JsonObject field = fields.get(i).getAsJsonObject();
-			String name = field.get("field").getAsString();
+			String name = field.get(FIELD).getAsString();
 			JsonObject fieldResponse = new JsonObject();
 			Resource resource = getDMClient().getDeviceData().getResource(name);
 			if(resource != null) {
 				resource.addPropertyChangeListener(Resource.ChangeListenerType.INTERNAL, this);
 				fieldsMap.put(name, resource);
 			}
-			fieldResponse.addProperty("field", name);
+			fieldResponse.addProperty(FIELD, name);
 			JsonElement value = resource.toJsonObject();
 			fieldResponse.add("value", value);
 			responseMap.put(name, value);
@@ -85,7 +88,7 @@ public class ObserveRequestHandler extends DMRequestHandler implements PropertyC
 		}
 	
 		JsonObject responseFileds = new JsonObject();
-		responseFileds.add("fields", responseArray);
+		responseFileds.add(FIELDS, responseArray);
 		response.add("d", responseFileds);
 		response.add("reqId", jsonRequest.get("reqId"));
 		response.add("rc", new JsonPrimitive(ResponseCode.DM_SUCCESS.getCode()));
@@ -101,7 +104,7 @@ public class ObserveRequestHandler extends DMRequestHandler implements PropertyC
 		if(resource != null) {
 			JsonObject response = new JsonObject();
 			JsonObject field = new JsonObject();
-			field.add("field", new JsonPrimitive(resource.getCanonicalName()));
+			field.add(FIELD, new JsonPrimitive(resource.getCanonicalName()));
 			JsonElement value = resource.toJsonObject();
 			JsonElement trimedValue = trimResponse(evt.getPropertyName(), value);
 			if(null == trimedValue) {
@@ -111,7 +114,7 @@ public class ObserveRequestHandler extends DMRequestHandler implements PropertyC
 			JsonObject fields = new JsonObject();
 			JsonArray fieldsArray = new JsonArray();
 			fieldsArray.add(field);
-			fields.add("fields", fieldsArray);
+			fields.add(FIELDS, fieldsArray);
 			response.add("d", fields);
 			notify(response);
 		}
@@ -122,7 +125,7 @@ public class ObserveRequestHandler extends DMRequestHandler implements PropertyC
 		LoggerUtility.fine(CLASS_NAME, METHOD,  "Cancel observation for " + fields);
 		for (int i=0; i < fields.size(); i++) {
 			JsonObject obj = (JsonObject)fields.get(i);
-			String name = obj.get("field").getAsString();
+			String name = obj.get(FIELD).getAsString();
 			Resource resource = fieldsMap.remove(name);
 			if(null != resource) {
 				resource.removePropertyChangeListener(this);

--- a/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/RebootRequestHandler.java
+++ b/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/RebootRequestHandler.java
@@ -40,6 +40,7 @@ import com.ibm.iotf.util.LoggerUtility;
  */
 public class RebootRequestHandler extends DMRequestHandler implements PropertyChangeListener {
 
+	private static final String REQ_ID = "reqId";
 	private JsonElement reqId;
 
 	public RebootRequestHandler(ManagedClient dmClient) {
@@ -66,7 +67,7 @@ public class RebootRequestHandler extends DMRequestHandler implements PropertyCh
 		if (action == null || getDMClient().getActionHandler() == null) {
 			// this should never happen
 			JsonObject response = new JsonObject();
-			response.add("reqId", jsonRequest.get("reqId"));
+			response.add(REQ_ID, jsonRequest.get(REQ_ID));
 			response.add("rc", new JsonPrimitive(ResponseCode.DM_FUNCTION_NOT_IMPLEMENTED.getCode()));
 			respond(response);
 		} else {
@@ -74,7 +75,7 @@ public class RebootRequestHandler extends DMRequestHandler implements PropertyCh
 			// remove any other listener that are listening for the status update
 			((ConcreteDeviceAction)action).clearListener();
 			((ConcreteDeviceAction)action).addPropertyChangeListener(this);
-			this.reqId = jsonRequest.get("reqId");
+			this.reqId = jsonRequest.get(REQ_ID);
 			DeviceActionHandler handler = getDMClient().getActionHandler();
 			handler.handleReboot(action);
 		} 
@@ -86,7 +87,7 @@ public class RebootRequestHandler extends DMRequestHandler implements PropertyCh
 			try {
 				ConcreteDeviceAction action = (ConcreteDeviceAction) evt.getNewValue();
 				JsonObject response = action.toJsonObject();
-				response.add("reqId", reqId);
+				response.add(REQ_ID, reqId);
 				respond(response);
 			} catch(Exception e) {
 				LoggerUtility.warn(CLASS_NAME, "propertyChange", e.getMessage());

--- a/src/main/java/com/ibm/iotf/client/AbstractClient.java
+++ b/src/main/java/com/ibm/iotf/client/AbstractClient.java
@@ -55,6 +55,8 @@ import com.ibm.iotf.util.LoggerUtility;
 public abstract class AbstractClient {
 	
 	private static final String CLASS_NAME = AbstractClient.class.getName();
+	private static final String QUICK_START = "quickstart";
+	
 	protected static final String CLIENT_ID_DELIMITER = ":";
 	
 	//protected static final String DOMAIN = "messaging.staging.internetofthings.ibmcloud.com";
@@ -171,7 +173,7 @@ public abstract class AbstractClient {
 		// clear the disconnect state when the user connects the client to Watson IoT Platform
 		disconnectRequested = false;  
 		
-		if (getOrgId() == "quickstart") {
+		if (getOrgId() == QUICK_START) {
 			configureMqtt();
 		}
 		else {
@@ -547,7 +549,7 @@ public abstract class AbstractClient {
 		validateNull("Device Type", deviceType);
 		validateNull("Device ID", deviceId);
 		validateNull("Event Name", eventName);
-		if("quickstart".equalsIgnoreCase(organization) == false) {
+		if(QUICK_START.equalsIgnoreCase(organization) == false) {
 			validateNull("Authentication Method", authKey);
 			validateNull("Authentication Token", authToken);
 		}
@@ -555,7 +557,7 @@ public abstract class AbstractClient {
 		StringBuilder sb = new StringBuilder();
 		
 		// Form the URL
-		if("quickstart".equalsIgnoreCase(organization)) {
+		if(QUICK_START.equalsIgnoreCase(organization)) {
 			sb.append("http://");
 		} else {
 			sb.append("https://");
@@ -602,7 +604,7 @@ public abstract class AbstractClient {
 		post.addHeader("Content-Type", "application/json");
 		post.addHeader("Accept", "application/json");
 		
-		if("quickstart".equalsIgnoreCase(organization) == false) {
+		if(QUICK_START.equalsIgnoreCase(organization) == false) {
 			byte[] encoding = Base64.encodeBase64(new String(authKey + ":" + authToken).getBytes() );			
 			String encodedString = new String(encoding);
 			post.addHeader("Authorization", "Basic " + encodedString);


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1192 - “String literals should not be duplicated”. 
This PR will remove 48 min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1192
 Please let me know if you have any questions.
Fevzi Ozgul
