### PR TITLE
Fixing squid: S1854 Dead stores should be removed part 1

### DIFF
--- a/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/CancelRequestHandler.java
+++ b/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/CancelRequestHandler.java
@@ -49,7 +49,7 @@ public class CancelRequestHandler extends DMRequestHandler {
 	 */
 	@Override
 	protected void handleRequest(JsonObject jsonRequest) {
-		JsonArray fields = null;
+		JsonArray fields;
 		JsonObject d = (JsonObject)jsonRequest.get("d");
 		if (d != null) {
 			fields = (JsonArray)d.get("data");

--- a/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/DeviceUpdateRequestHandler.java
+++ b/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/DeviceUpdateRequestHandler.java
@@ -95,7 +95,7 @@ public class DeviceUpdateRequestHandler extends DMRequestHandler {
 	public void handleRequest(JsonObject jsonRequest) {
 		final String METHOD = "handleRequest";
 		List<Resource> fireRequiredResources = new ArrayList<Resource>();
-		JsonArray fields = null;
+		JsonArray fields;
 		ResponseCode rc = ResponseCode.DM_UPDATE_SUCCESS;
 		JsonObject response = new JsonObject();
 		JsonObject d = (JsonObject)jsonRequest.get("d");

--- a/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/FirmwareDownloadRequestHandler.java
+++ b/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/FirmwareDownloadRequestHandler.java
@@ -65,7 +65,7 @@ public class FirmwareDownloadRequestHandler extends DMRequestHandler {
 	@Override
 	public void handleRequest(JsonObject jsonRequest) {
 		final String METHOD = "handleRequest";
-		ResponseCode rc = ResponseCode.DM_INTERNAL_ERROR;
+		ResponseCode rc;
 		
 		JsonObject response = new JsonObject();
 		response.add("reqId", jsonRequest.get("reqId"));


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1854 - “ Dead stores should be removed ”.
This PR will remove 48 min of TD. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1854
 Please let me know if you have any questions.
Fevzi Ozgul
