### PR TITLE
Fixing squid: MethodCyclomaticComplexity "Methods should not be too complex

### DIFF
--- a/src/main/java/com/ibm/internal/iotf/devicemgmt/device/DeviceDMServerTopic.java
+++ b/src/main/java/com/ibm/internal/iotf/devicemgmt/device/DeviceDMServerTopic.java
@@ -13,6 +13,9 @@
  */
 package com.ibm.internal.iotf.devicemgmt.device;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.ibm.internal.iotf.devicemgmt.DMServerTopic;
 
 /**
@@ -22,6 +25,18 @@ import com.ibm.internal.iotf.devicemgmt.DMServerTopic;
 public class DeviceDMServerTopic implements DMServerTopic {
 	
 	private static DeviceDMServerTopic instance = new DeviceDMServerTopic();
+	private static final Map<String, Object> SERVER_TOPIC = new HashMap<>();
+	static {
+		SERVER_TOPIC.put("iotdm-1/response", ServerTopic.RESPONSE);
+		SERVER_TOPIC.put("iotdm-1/observe", ServerTopic.OBSERVE);
+		SERVER_TOPIC.put("iotdm-1/cancel", ServerTopic.CANCEL);
+		SERVER_TOPIC.put("iotdm-1/mgmt/initiate/device/reboot", ServerTopic.INITIATE_REBOOT);
+		SERVER_TOPIC.put("iotdm-1/mgmt/initiate/device/factory_reset", ServerTopic.INITIATE_FACTORY_RESET);
+		SERVER_TOPIC.put("iotdm-1/mgmt/initiate/firmware/download", ServerTopic.INITIATE_FIRMWARE_DOWNLOAD);
+		SERVER_TOPIC.put("iotdm-1/mgmt/initiate/firmware/update", ServerTopic.INITIATE_FIRMWARE_UPDATE);
+		SERVER_TOPIC.put("iotdm-1/device/update", ServerTopic.DEVICE_UPDATE);
+	}
+	
 
 	enum ServerTopic {
 		RESPONSE("iotdm-1/response"),
@@ -51,25 +66,7 @@ public class DeviceDMServerTopic implements DMServerTopic {
 		 * @return the ServerTopic for the given string
 		 */
 		public static ServerTopic get(String topic) {
-			switch(topic) {
-			case "iotdm-1/response": return RESPONSE;
-			
-			case ("iotdm-1/observe"): return OBSERVE;
-			
-			case "iotdm-1/cancel": return CANCEL;
-			
-			case "iotdm-1/mgmt/initiate/device/reboot": return INITIATE_REBOOT;
-			
-			case "iotdm-1/mgmt/initiate/device/factory_reset": return INITIATE_FACTORY_RESET;
-			
-			case "iotdm-1/mgmt/initiate/firmware/download": return INITIATE_FIRMWARE_DOWNLOAD;
-			
-			case "iotdm-1/mgmt/initiate/firmware/update": return INITIATE_FIRMWARE_UPDATE;
-			
-			case "iotdm-1/device/update": return DEVICE_UPDATE;
-			
-			}
-			return null;
+			return (ServerTopic)SERVER_TOPIC.get(topic);
 		}
 
 	}


### PR DESCRIPTION
  This pull request is focused on resolving occurrences of Sonar rule 
 squid:MethodCyclomaticComplexity - “Methods should not be complex”. 
This PR will remove 34min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid: MethodCyclomaticComplexity
 Please let me know if you have any questions.
Fevzi Ozgul
