### PR TITLE
Build additional JAR with dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,22 @@
 				    <goals>deploy</goals>
 				</configuration>
 		    </plugin>
+	    <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+       	        <version>2.4</version>
+        	<executions>
+          	    <execution>
+            		<phase>package</phase>
+            		<goals>
+              		    <goal>shade</goal>
+            		</goals>
+            	        <configuration>
+              	 	    <shadedArtifactAttached>true</shadedArtifactAttached>
+              		    <shadedClassifierName>with-deps</shadedClassifierName>
+            	        </configuration>
+          	    </execution>
+        	</executions>
+            </plugin>
         </plugins>
     </build>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -225,18 +225,18 @@
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-       	        <version>2.4</version>
-        	<executions>
-          	    <execution>
-            	        <phase>package</phase>
-            	        <goals>
-              		    <goal>shade</goal>
-            	        </goals>
-            	        <configuration>
-           		    <shadedArtifactAttached>true</shadedArtifactAttached>
-              		    <shadedClassifierName>with-deps</shadedClassifierName>
-            	        </configuration>
-          	    </execution>
+                <version>2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>with-deps</shadedClassifierName>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -188,56 +188,56 @@
                 </executions>
             </plugin>
             <plugin>
-		    	<groupId>org.apache.maven.plugins</groupId>
-		      	<artifactId>maven-gpg-plugin</artifactId>
-		      	<version>1.5</version>
-		      	<executions>
-		        	<execution>
-		          		<id>sign-artifacts</id>
-		          		<phase>verify</phase>
-		          		<goals>
-		            		<goal>sign</goal>
-		          		</goals>
-		        	</execution>
-		      	</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.3</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>ossrh</serverId>
-				    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-				    <autoReleaseAfterClose>false</autoReleaseAfterClose>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5</version>
-				<configuration>
-				    <autoVersionSubmodules>true</autoVersionSubmodules>
-				    <useReleaseProfile>false</useReleaseProfile>
-				    <releaseProfiles>release</releaseProfiles>
-				    <goals>deploy</goals>
-				</configuration>
-		    </plugin>
-	    <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.3</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <goals>deploy</goals>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
        	        <version>2.4</version>
         	<executions>
           	    <execution>
-            		<phase>package</phase>
-            		<goals>
+            	        <phase>package</phase>
+            	        <goals>
               		    <goal>shade</goal>
-            		</goals>
+            	        </goals>
             	        <configuration>
-              	 	    <shadedArtifactAttached>true</shadedArtifactAttached>
+           		    <shadedArtifactAttached>true</shadedArtifactAttached>
               		    <shadedClassifierName>with-deps</shadedClassifierName>
             	        </configuration>
           	    </execution>
-        	</executions>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Add a plugin to build an additional JAR target which includes all dependencies. This can be useful if you are building the JAR to sit on a target platform rather than adding it as part of a code project.

Additional XML formatting fixes.
