### PR TITLE
Fix Firmware Update issue and Enable WebSocket support

### DIFF
--- a/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/FirmwareUpdateRequestHandler.java
+++ b/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/FirmwareUpdateRequestHandler.java
@@ -83,8 +83,8 @@ public class FirmwareUpdateRequestHandler extends DMRequestHandler {
 		DeviceFirmware firmware = getDMClient().getDeviceData().getDeviceFirmware();
 		if(firmware == null || getDMClient().getFirmwareHandler() == null) {
 			rc = ResponseCode.DM_FUNCTION_NOT_IMPLEMENTED;
-		} else if(firmware.getState() == DeviceFirmware.FirmwareState.IDLE.getState()) {
-			rc = ResponseCode.DM_BAD_REQUEST;
+		//} else if(firmware.getState() == DeviceFirmware.FirmwareState.IDLE.getState()) {
+		//	rc = ResponseCode.DM_BAD_REQUEST;
 		} else {
 			// Normal condition
 			

--- a/src/main/java/com/ibm/iotf/client/AbstractClient.java
+++ b/src/main/java/com/ibm/iotf/client/AbstractClient.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
+import java.security.Provider;
+import java.security.Provider.Service;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -315,12 +317,17 @@ public abstract class AbstractClient {
 			 * SSLContext sslContext = SSLContextUtils.createSSLContext("TLSv1.2", null, trustManager);
 			 * 
 			 */
-			 
-			if (!isWebSocket()) {
-				SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
-				sslContext.init(null, null, null);
-				mqttClientOptions.setSocketFactory(sslContext.getSocketFactory());
+			
+			Provider[] providers = java.security.Security.getProviders();
+			for (Provider provider : providers) {
+				LoggerUtility.info(CLASS_NAME, METHOD, "Provider: " + provider.getName());
+				for (Service service : provider.getServices()) {
+					LoggerUtility.info(CLASS_NAME, METHOD, "Algorithm: " + service.getAlgorithm());
+				}
 			}
+			SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+			sslContext.init(null, null, null);
+			mqttClientOptions.setSocketFactory(sslContext.getSocketFactory());
 		} catch (MqttException | GeneralSecurityException e) {
 			LoggerUtility.warn(CLASS_NAME, METHOD, "Unable to configure TLSv1.2 connection: " + e.getMessage());
 			e.printStackTrace();

--- a/src/main/java/com/ibm/iotf/client/AbstractClient.java
+++ b/src/main/java/com/ibm/iotf/client/AbstractClient.java
@@ -177,10 +177,9 @@ public abstract class AbstractClient {
 		// clear the disconnect state when the user connects the client to Watson IoT Platform
 		disconnectRequested = false;  
 		
-		if (getOrgId() == QUICK_START) {
+		if (getOrgId() == QUICK_START || !isSecureConnection()) {
 			configureMqtt();
-		}
-		else {
+		} else {
 			configureMqtts();
 		}
 		
@@ -353,6 +352,15 @@ public abstract class AbstractClient {
 	private boolean isWebSocket() {
 		boolean enabled = false;
 		String value = options.getProperty("WebSocket");
+		if (value != null) {
+			enabled = Boolean.parseBoolean(trimedValue(value));
+		}
+		return enabled;
+	}
+	
+	private boolean isSecureConnection() {
+		boolean enabled = false;
+		String value = options.getProperty("SecureConnection");
 		if (value != null) {
 			enabled = Boolean.parseBoolean(trimedValue(value));
 		}

--- a/src/main/java/com/ibm/iotf/client/AbstractClient.java
+++ b/src/main/java/com/ibm/iotf/client/AbstractClient.java
@@ -317,7 +317,7 @@ public abstract class AbstractClient {
 			 * SSLContext sslContext = SSLContextUtils.createSSLContext("TLSv1.2", null, trustManager);
 			 * 
 			 */
-			
+			/*
 			Provider[] providers = java.security.Security.getProviders();
 			for (Provider provider : providers) {
 				LoggerUtility.info(CLASS_NAME, METHOD, "Provider: " + provider.getName());
@@ -325,7 +325,9 @@ public abstract class AbstractClient {
 					LoggerUtility.info(CLASS_NAME, METHOD, "Algorithm: " + service.getAlgorithm());
 				}
 			}
+			*/
 			SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+			LoggerUtility.info(CLASS_NAME, METHOD, "Provider: " + sslContext.getProvider().getName());
 			sslContext.init(null, null, null);
 			mqttClientOptions.setSocketFactory(sslContext.getSocketFactory());
 		} catch (MqttException | GeneralSecurityException e) {

--- a/src/main/java/com/ibm/iotf/client/AbstractClient.java
+++ b/src/main/java/com/ibm/iotf/client/AbstractClient.java
@@ -65,6 +65,7 @@ public abstract class AbstractClient {
 	protected static final String MESSAGING = "messaging";
 	protected static final int MQTT_PORT = 1883;
 	protected static final int MQTTS_PORT = 8883;
+	protected static final int WSS_PORT = 443;
 	private volatile boolean disconnectRequested = false;
 	
 	/* Wait for 1 second after each attempt for the first 10 attempts*/
@@ -261,7 +262,16 @@ public abstract class AbstractClient {
 	
 	private void configureMqtts() {
 		final String METHOD = "configureMqtts";
-		String serverURI = "ssl://" + getOrgId() + "." + MESSAGING + "." + this.getDomain() + ":" + MQTTS_PORT;
+		String protocol = null;
+		int port;
+		if (isWebSocket()) {
+			protocol = "wss://";
+			port = WSS_PORT;
+		} else {
+			protocol = "ssl://";
+			port = MQTTS_PORT;
+		}
+		String serverURI = protocol + getOrgId() + "." + MESSAGING + "." + this.getDomain() + ":" + port;
 		try {
 			mqttAsyncClient = new MqttAsyncClient(serverURI, clientId, null);
 			mqttAsyncClient.setCallback(mqttCallback);
@@ -322,6 +332,15 @@ public abstract class AbstractClient {
 		if(value != null) {
 			enabled = Boolean.parseBoolean(trimedValue(value));
 		} 
+		return enabled;
+	}
+	
+	private boolean isWebSocket() {
+		boolean enabled = false;
+		String value = options.getProperty("WebSocket");
+		if (value != null) {
+			enabled = Boolean.parseBoolean(trimedValue(value));
+		}
 		return enabled;
 	}
 


### PR DESCRIPTION
In this pull request:
- I modified `FirmwareUpdateRequestHandler` class to allow firmware update regardless of firmware state.  In a typical scenario, a device client connects, sends manage request, got firmware download request, then got reboot request.  When the device client connects after rebooting the firmware state is actually IDLE, therefore we should allow firmware update to go through.
- I modified `AbstractClient` class to replace `configureMqtt()` and `configureMqtts()` with one method `configureConnOptions()` in which the connection properties are set according to input properties.  Two new input properties are `WebSocket` and `Secure` (default is set to `false`).  I built and ran jUnit tests, existing tests worked as expected.
