### PR TITLE
New MaxInflightMessgaes option, new method to initiate DM action, exception message constants

### DIFF
--- a/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/FirmwareDownloadRequestHandler.java
+++ b/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/FirmwareDownloadRequestHandler.java
@@ -76,8 +76,6 @@ public class FirmwareDownloadRequestHandler extends DMRequestHandler {
 			rc = ResponseCode.DM_BAD_REQUEST;		
 		} else {
 			if (deviceFirmware.getUrl() != null) {
-				LoggerUtility.fine(CLASS_NAME, METHOD, "fire firmware download");
-				getDMClient().getFirmwareHandler().downloadFirmware(deviceFirmware);
 				rc = ResponseCode.DM_ACCEPTED;
 			} else {
 				rc = ResponseCode.DM_BAD_REQUEST;
@@ -86,5 +84,9 @@ public class FirmwareDownloadRequestHandler extends DMRequestHandler {
 		} 
 		response.add("rc", new JsonPrimitive(rc.getCode()));
 		respond(response);
+		if (rc == ResponseCode.DM_ACCEPTED) {
+			LoggerUtility.fine(CLASS_NAME, METHOD, "fire firmware download");
+			getDMClient().getFirmwareHandler().downloadFirmware(deviceFirmware);			
+		}
 	}
 }

--- a/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/FirmwareUpdateRequestHandler.java
+++ b/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/FirmwareUpdateRequestHandler.java
@@ -89,8 +89,6 @@ public class FirmwareUpdateRequestHandler extends DMRequestHandler {
 			// Normal condition
 			
 			if (firmware.getUrl() != null) {
-				LoggerUtility.fine(CLASS_NAME, METHOD, "Fire Firmware update ");
-				getDMClient().getFirmwareHandler().updateFirmware(firmware);
 				rc = ResponseCode.DM_ACCEPTED;
 			} else {
 				rc = ResponseCode.DM_BAD_REQUEST;
@@ -100,6 +98,10 @@ public class FirmwareUpdateRequestHandler extends DMRequestHandler {
 
 		response.add("rc", new JsonPrimitive(rc.getCode()));
 		respond(response);
+		if (rc == ResponseCode.DM_ACCEPTED) {
+			LoggerUtility.fine(CLASS_NAME, METHOD, "Fire Firmware update ");
+			getDMClient().getFirmwareHandler().updateFirmware(firmware);			
+		}
 	}
 
 }

--- a/src/main/java/com/ibm/iotf/client/AbstractClient.java
+++ b/src/main/java/com/ibm/iotf/client/AbstractClient.java
@@ -57,6 +57,7 @@ public abstract class AbstractClient {
 	
 	private static final String CLASS_NAME = AbstractClient.class.getName();
 	private static final String QUICK_START = "quickstart";
+	private static final int DEFAULT_MAX_INFLIGHT_MESSAGES = 100;
 	
 	protected static final String CLIENT_ID_DELIMITER = ":";
 	
@@ -271,6 +272,7 @@ public abstract class AbstractClient {
 			if(this.keepAliveInterval != -1) {
 				mqttClientOptions.setKeepAliveInterval(this.keepAliveInterval);
 			}
+			mqttClientOptions.setMaxInflight(getMaxInflight());
 		} catch (MqttException e) {
 			e.printStackTrace();
 		}
@@ -314,6 +316,8 @@ public abstract class AbstractClient {
 			if(this.keepAliveInterval != -1) {
 				mqttClientOptions.setKeepAliveInterval(this.keepAliveInterval);
 			}
+			
+			mqttClientOptions.setMaxInflight(getMaxInflight());
 			
 			/* This isn't needed as the production messaging.internetofthings.ibmcloud.com 
 			 * certificate should already be in trust chain.
@@ -386,6 +390,15 @@ public abstract class AbstractClient {
 			enabled = Boolean.parseBoolean(trimedValue(value));
 		}
 		return enabled;
+	}
+	
+	private int getMaxInflight() {
+		int maxInflight = DEFAULT_MAX_INFLIGHT_MESSAGES;
+		String value = options.getProperty("MaxInflightMessages");
+		if (value != null) {
+			maxInflight = Integer.parseInt(trimedValue(value));
+		}
+		return maxInflight;
 	}
 
 	/**

--- a/src/main/java/com/ibm/iotf/client/IoTFCReSTException.java
+++ b/src/main/java/com/ibm/iotf/client/IoTFCReSTException.java
@@ -16,29 +16,95 @@ import com.google.gson.JsonElement;
 
 public class IoTFCReSTException extends Exception {
 	
-	private int httpCode;
-	private JsonElement response;
+	public static final String HTTP_ERR_UNEXPECTED = "Unexpected error code";
+	public static final String HTTP_ERR_500 = "Unexpected error";
+	public static final String HTTP_ADD_DEVICE_ERR_400 = 
+			"Invalid request (No body, invalid JSON, unexpected key, bad value)";
+	public static final String HTTP_ADD_DEVICE_ERR_401 = 
+			"The authentication token is empty or invalid";
+	public static final String HTTP_ADD_DEVICE_ERR_403 = 
+			"The authentication method is invalid or the API key used does not exist";
+	public static final String HTTP_ADD_DEVICE_ERR_409 =
+			"The device already exists";
+	public static final String HTTP_ADD_DEVICE_ERR_500 = HTTP_ERR_500;
 	
-	public IoTFCReSTException(int httpCode, String message, 
-			JsonElement response) {
-		super(message);
+	public static final String HTTP_ADD_DM_EXTENSION_ERR_400 =
+			"Invalid request";
+	public static final String HTTP_ADD_DM_EXTENSION_ERR_401 =
+			"Unauthorized";
+	public static final String HTTP_ADD_DM_EXTENSION_ERR_403 =
+			"Forbidden";
+	public static final String HTTP_ADD_DM_EXTENSION_ERR_409 =
+			"Conflict";
+	public static final String HTTP_ADD_DM_EXTENSION_ERR_500 =
+			"Internal server error";
+	public static final String HTTP_INITIATE_DM_REQUEST_ERR_500 = HTTP_ERR_500;
+	
+	private String method = null;
+	private String url = null;
+	private int httpCode;
+	private JsonElement response = null;
+	private String request = null;
+	
+	/**
+	 * 
+	 * @param method One of the HTTP methods ("get","post", "put", "delete")
+	 * @param url URL of the ReST call
+	 * @param request Requested parameters or NULL
+	 * @param httpCode Returned code from Watson IoT Platform
+	 * @param reason Reason for the exception
+	 * @param response Response from Watson IoT Platform or NULL
+	 */
+	public IoTFCReSTException(String method, String url, String request, 
+			int httpCode, String reason, JsonElement response) {
+		super(reason);
+		this.method = method;
+		this.url = url;
+		this.request = request;
 		this.httpCode = httpCode;
 		this.response = response;
 	}
-
-	public IoTFCReSTException(String message) {
-		super(message);
+	
+	public IoTFCReSTException(int httpCode, String reason, JsonElement response) {
+		super(reason);
+		this.httpCode = httpCode;
+		this.response = response;
 	}
-
-	public IoTFCReSTException(int code, String message) {
-		super(message);
-		this.httpCode = code;
+	
+	public IoTFCReSTException(int httpCode, String reason) {
+		super(reason);
+		this.httpCode = httpCode;
+	}
+	
+	public IoTFCReSTException(String reason, JsonElement response) {
+		super(reason);
+		this.response = response;
+	}
+	
+	public IoTFCReSTException(String reason) {
+		super(reason);
+	}
+	
+	public String getMethodL() {
+		return method;
+	}
+	
+	public String getURL() {
+		return url;
+	}
+	
+	public String getRequest() {
+		return request;
 	}
 
 	public int getHttpCode() {
 		return httpCode;
 	}
 
+	/**
+	 * Return the response from Watson IoT or null.
+	 * @return JsonElement or null
+	 */
 	public JsonElement getResponse() {
 		return response;
 	}


### PR DESCRIPTION
Included in this pull request are:
- A new option for `MaxInflightMessages` (default is 100) - Note that without specifying a maximum inflight messages value, the Paho client will allow only 10 inflight messages. This is not practical for Device Management protocol.
- A new method `initiateDMRequest()` to return the response from Watson IoT Platform. This is useful for applications to retrieve information about the request such as reqId field to check on requests
- Move exception messages from `APIClient` class to `IoTFCReSTException` class as constant strings.  This way the messages can be defined in one place and can be reused .
- New constructor for `IoTFCReSTException` class - This allows application to check on the actual HTTP method and request string when the API failed.
