### PR TITLE
New SSL option for APIClient, QoS option for DM MQTT clients

### DIFF
--- a/src/main/java/com/ibm/internal/iotf/devicemgmt/ManagedClient.java
+++ b/src/main/java/com/ibm/internal/iotf/devicemgmt/ManagedClient.java
@@ -32,6 +32,8 @@ public interface ManagedClient {
 
 	public void unsubscribe(String topic) throws MqttException;
 
+	public void publish(String response, JsonObject payload) throws MqttException;
+	
 	public void publish(String response, JsonObject payload, int qos) throws MqttException;
 
 	public DeviceData getDeviceData();

--- a/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/DMRequestHandler.java
+++ b/src/main/java/com/ibm/internal/iotf/devicemgmt/handler/DMRequestHandler.java
@@ -83,7 +83,7 @@ public abstract class DMRequestHandler implements IMqttMessageListener {
 		final String METHOD = "respond";
 		try {
 			DMAgentTopic topic = dmClient.getDMAgentTopic();
-			dmClient.publish(topic.getDMServerTopic(), payload, 1);
+			dmClient.publish(topic.getDMServerTopic(), payload);
 		} catch (MqttException e) {
 			LoggerUtility.severe(CLASS_NAME, METHOD, "Unexpected Mqtt Exception, code = " + e.getReasonCode());
 		}
@@ -93,7 +93,7 @@ public abstract class DMRequestHandler implements IMqttMessageListener {
 		final String METHOD = "notify";
 		try {
 			DMAgentTopic topic = dmClient.getDMAgentTopic();
-			dmClient.publish(topic.getNotifyTopic(), payload, 1);
+			dmClient.publish(topic.getNotifyTopic(), payload);
 		} catch (MqttException e) {
 			LoggerUtility.severe(CLASS_NAME, METHOD, "Unexpected Mqtt Exception, code = " + e.getReasonCode());
 		}

--- a/src/main/java/com/ibm/iotf/client/AbstractClient.java
+++ b/src/main/java/com/ibm/iotf/client/AbstractClient.java
@@ -58,6 +58,7 @@ public abstract class AbstractClient {
 	private static final String CLASS_NAME = AbstractClient.class.getName();
 	private static final String QUICK_START = "quickstart";
 	private static final int DEFAULT_MAX_INFLIGHT_MESSAGES = 100;
+	private static final int DEFAULT_MESSAGING_QOS = 1;
 	
 	protected static final String CLIENT_ID_DELIMITER = ":";
 	
@@ -392,13 +393,25 @@ public abstract class AbstractClient {
 		return enabled;
 	}
 	
-	private int getMaxInflight() {
+	public int getMaxInflight() {
 		int maxInflight = DEFAULT_MAX_INFLIGHT_MESSAGES;
 		String value = options.getProperty("MaxInflightMessages");
 		if (value != null) {
 			maxInflight = Integer.parseInt(trimedValue(value));
 		}
 		return maxInflight;
+	}
+	
+	public int getMessagingQoS() {
+		int qos = DEFAULT_MESSAGING_QOS;
+		String value = options.getProperty("MessagingQoS");
+		if (value != null) {
+			qos = Integer.parseInt(trimedValue(value));
+			if (qos < 0 || qos > 2) {
+				qos = DEFAULT_MESSAGING_QOS;
+			}
+		}
+		return qos;
 	}
 
 	/**

--- a/src/main/java/com/ibm/iotf/client/api/APIClient.java
+++ b/src/main/java/com/ibm/iotf/client/api/APIClient.java
@@ -104,17 +104,27 @@ public class APIClient {
 			authKey = "g/" + this.orgId + '/' + this.getGWDeviceType(opt) + '/' + this.getGWDeviceId(opt);
 		}
 		
-		TrustManager[] trustAllCerts = new TrustManager[] { new X509TrustManager() {
-			public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-				return new X509Certificate[0];
-			}
-
-			public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType) {
-			}
-
-			public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType) {
-			}
-		} };
+		TrustManager[] trustAllCerts = null;
+		boolean trustAll = false;
+		
+		String value = opt.getProperty("Trust-All-Certificates");
+		if (value != null) {
+			trustAll = Boolean.parseBoolean(trimedValue(value));
+		}
+		
+		if (trustAll) {
+			trustAllCerts = new TrustManager[] { new X509TrustManager() {
+				public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+					return new X509Certificate[0];
+				}
+	
+				public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType) {
+				}
+	
+				public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType) {
+				}
+			} };
+		}
 
 		sslContext = SSLContext.getInstance("TLSv1.2");
 		sslContext.init(null, trustAllCerts, null);


### PR DESCRIPTION
Changes included in this pull request:
1.  During load testing, I found out that the APIClient cannot connect to loadtest.internetofthings.ibmcloud.com - I added an optional property "Trust-All-Certificates" (default is false) which will allow the APIClient to connect.
2.  For performance purpose, let the device developer specify the QoS to be used for publish to Watson IoT Platform
