### PR TITLE
Fix to handle when default charset is not UTF-8

### DIFF
--- a/src/main/java/com/ibm/iotf/client/AbstractClient.java
+++ b/src/main/java/com/ibm/iotf/client/AbstractClient.java
@@ -675,8 +675,7 @@ public abstract class AbstractClient {
 		
 		LoggerUtility.fine(CLASS_NAME, METHOD, "ReST URL::"+sb.toString());
 		BufferedReader br = null;
-		br = new BufferedReader(new InputStreamReader(System.in));
-		
+	
 		// Create the payload message in Json format
 		JsonObject message = (JsonObject) gson.toJsonTree(payload);		
 		StringEntity input = new StringEntity(message.toString(), StandardCharsets.UTF_8);
@@ -722,7 +721,7 @@ public abstract class AbstractClient {
 					.append('\n');
 			}
 			log.append("\nResponse \n");
-			br = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
+			br = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8));
 			log.append(br.readLine());
 			LoggerUtility.severe(CLASS_NAME, METHOD, log.toString());
 			

--- a/src/main/java/com/ibm/iotf/client/api/APIClient.java
+++ b/src/main/java/com/ibm/iotf/client/api/APIClient.java
@@ -303,7 +303,7 @@ public class APIClient {
 	private String readContent(HttpResponse response, String method) 
 			throws IllegalStateException, IOException {
 		
-		BufferedReader br = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
+		BufferedReader br = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8));
 		String line = null;
 		try {
 			line = br.readLine();

--- a/src/test/java/com/ibm/iotf/client/gateway/GatewayEventPublishTest.java
+++ b/src/test/java/com/ibm/iotf/client/gateway/GatewayEventPublishTest.java
@@ -215,8 +215,9 @@ public class GatewayEventPublishTest extends TestCase{
 	 * can publish its own events as well. 
 	 * 
 	 * The test verifies whether the gateway can publish an event to the Platform
+	 * @throws Exception 
 	 */
-	public void testGatewayEventPublishMethod() {
+	public void testGatewayEventPublishMethod() throws Exception {
 		
 		if(gwClient.isConnected() == false) {
 			return;
@@ -241,21 +242,28 @@ public class GatewayEventPublishTest extends TestCase{
 		
 		// publish using default QoS0
 		code = gwClient.publishGatewayEvent("blink", event, 1);
+
+		// custom publish
+		code = gwClient.publishGatewayEvent("blink", "rotation:80", "text", 1);
 		assertTrue("Failed to publish the event......", code);
-		
+
+		// custom publish
+		code = gwClient.publishGatewayEvent("blink", new byte[]{80}, "binary", 1);
+		assertTrue("Failed to publish the event......", code);
+
+		// try publish after disconnect
 		gwClient.disconnect();
 		code = gwClient.publishGatewayEvent("blink", event, 1);
 		assertFalse("Should not publish an event after disconnect......", code);
-		
-		// try publish after disconnect
 				
 		System.out.println("Successfully published a Gateway event !!");
 	}
 	
 	/**
 	 * The test verifies whether the gateway can publish an event for the attached device to the Platform
+	 * @throws Exception 
 	 */
-	public void testDeviceEventPublishMethod() {
+	public void testDeviceEventPublishMethod() throws Exception {
 		
 		if(gwClient.isConnected() == false) {
 			return;
@@ -280,6 +288,14 @@ public class GatewayEventPublishTest extends TestCase{
 
 		// Publish using default QoS1
 		code = gwClient.publishDeviceEvent(DEVICE_TYPE, SIMULATOR_DEVICE_ID, "blink", null, 1);
+		assertTrue("Failed to publish the device event......", code);
+		
+		// Publish text event
+		code = gwClient.publishDeviceEvent(DEVICE_TYPE, SIMULATOR_DEVICE_ID, "blink", "rotation:80", "text", 2);
+		assertTrue("Failed to publish the device event......", code);
+				
+		// Publish using default QoS1
+		code = gwClient.publishDeviceEvent(DEVICE_TYPE, SIMULATOR_DEVICE_ID, "blink", new byte[]{90, 8, 9, 0}, "binary", 1);
 		assertTrue("Failed to publish the device event......", code);
 				
 		System.out.println("Successfully published a device event !!");

--- a/src/test/resources/gateway.properties
+++ b/src/test/resources/gateway.properties
@@ -11,7 +11,6 @@ Registration-Mode = Manual
 ## Mandatory if Registration-Mode is Manual
 API-Key = <Organization API Key>
 API-Token = <Organization API Token>
-
 ##Optional properties
 WebSocket = false
 Secure = true


### PR DESCRIPTION
The Java Client Library can corrupt the data returned by API calls if the default charset is not UTF-8. For example, if a device definition contains characters that are not in Windows code page Cp1252, and ApiClient.getAllDevices() is called to retrieve the device details, and the default charset is Cp1252, the characters will be corrupted.

This is an issue for globalization because the system should handle all Unicode characters without corruption.

The attached testcase [test.zip](https://github.com/ibm-watson-iot/iot-java/files/456772/test.zip) demonstrates the problem. It issues an ApiClient.getAllDevices() call and prints the hex values of the serialNumber field of each device it receives.
1. In the dashboard create a device and set its serialNumber field to the string between these double quotes:
   "
    "
   This might look like a load of blanks but is actually a string of characters with the hex values 80, 81, 82... 9F. These are chosen because they are valid code points in UTF-8 but are not valid code points in Cp1252.
2. Create an an application.properties file on the classpath containing details of your org and API key.
3. Run the attached testcase forcing the default charset to UTF-8:

java -Djavax.net.ssl.trustStore=${resource_loc:/iotcloud.build/IBMInternalCA-truststore.js} -Dfile.encoding=UTF-8 D153094

The following output is produced.

Default charset: UTF-8
serialNumber: 
80
81
82
83
...
9e
9f

It shows that, when the charset is UTF-8, the hex values of the serialNumber field are correctly preserved.
1. Now run the attached testcase forcing the default charset to Cp1252:

java -Djavax.net.ssl.trustStore=${resource_loc:/iotcloud.build/IBMInternalCA-truststore.js} -Dfile.encoding=Cp1252 D153094

Default charset: windows-1252
serialNumber: �?�?�?�?�?
c2
20ac
c2
fffd
c2
201a
c2
192
...
c2
17e
c2
178

This shows that, when the charset is not UTF-8, the hex values of the serialNumber field are garbled.
