### PR TITLE
Implement auto reconnect and offline buffering

### DIFF
--- a/src/main/java/com/ibm/iotf/client/AbstractClient.java
+++ b/src/main/java/com/ibm/iotf/client/AbstractClient.java
@@ -319,6 +319,7 @@ public abstract class AbstractClient {
 			}
 			
 			mqttClientOptions.setMaxInflight(getMaxInflight());
+			mqttClientOptions.setAutomaticReconnect(isAutomaticReconnect());
 			
 			/* This isn't needed as the production messaging.internetofthings.ibmcloud.com 
 			 * certificate should already be in trust chain.
@@ -363,7 +364,7 @@ public abstract class AbstractClient {
 	 * 
 	 * @return boolean value containing whether its a clean session or not.
 	 */
-	private boolean isCleanSession() {
+	public boolean isCleanSession() {
 		boolean enabled = true;
 		String value = options.getProperty("Clean-Session");
 		if(value == null) {
@@ -375,7 +376,7 @@ public abstract class AbstractClient {
 		return enabled;
 	}
 	
-	private boolean isWebSocket() {
+	public boolean isWebSocket() {
 		boolean enabled = false;
 		String value = options.getProperty("WebSocket");
 		if (value != null) {
@@ -384,9 +385,18 @@ public abstract class AbstractClient {
 		return enabled;
 	}
 	
-	private boolean isSecureConnection() {
-		boolean enabled = false;
+	public boolean isSecureConnection() {
+		boolean enabled = true;
 		String value = options.getProperty("Secure");
+		if (value != null) {
+			enabled = Boolean.parseBoolean(trimedValue(value));
+		}
+		return enabled;
+	}
+	
+	public boolean isAutomaticReconnect() {
+		boolean enabled = false;
+		String value = options.getProperty("Automatic-Reconnect");
 		if (value != null) {
 			enabled = Boolean.parseBoolean(trimedValue(value));
 		}

--- a/src/main/java/com/ibm/iotf/client/app/ApplicationClient.java
+++ b/src/main/java/com/ibm/iotf/client/app/ApplicationClient.java
@@ -215,7 +215,7 @@ public class ApplicationClient extends AbstractClient implements MqttCallback{
 	 * @return Whether the send was successful.
 	 */
 	public boolean publishEvent(String deviceType, String deviceId, String event, Object data, int qos) {
-		if (!isConnected()) {
+		if (!isConnected() && !isAutomaticReconnect()) {
 			return false;
 		}
 		final String METHOD = "publishEvent(5)";
@@ -242,7 +242,11 @@ public class ApplicationClient extends AbstractClient implements MqttCallback{
 		msg.setRetained(false);
 		
 		try {
-			mqttAsyncClient.publish(topic, msg).waitForCompletion();
+			if (isConnected() && !isAutomaticReconnect()) {
+				mqttAsyncClient.publish(topic, msg).waitForCompletion();
+			} else {
+				mqttAsyncClient.publish(topic, msg);
+			}
 		} catch (MqttPersistenceException e) {
 			e.printStackTrace();
 			return false;
@@ -290,7 +294,7 @@ public class ApplicationClient extends AbstractClient implements MqttCallback{
 	 * @return Whether the send was successful.
 	 */
 	public boolean publishCommand(String deviceType, String deviceId, String command, Object data, int qos) {
-		if (!isConnected()) {
+		if (!isConnected() && !isAutomaticReconnect()) {
 			return false;
 		}
 		final String METHOD = "publishCommand(5)";
@@ -317,7 +321,11 @@ public class ApplicationClient extends AbstractClient implements MqttCallback{
 		msg.setRetained(false);
 		
 		try {
-			mqttAsyncClient.publish(topic, msg).waitForCompletion();
+			if (isConnected() && !isAutomaticReconnect()) {
+				mqttAsyncClient.publish(topic, msg).waitForCompletion();
+			} else {
+				mqttAsyncClient.publish(topic, msg);
+			}
 		} catch (MqttPersistenceException e) {
 			e.printStackTrace();
 			return false;

--- a/src/main/java/com/ibm/iotf/client/device/DeviceClient.java
+++ b/src/main/java/com/ibm/iotf/client/device/DeviceClient.java
@@ -225,9 +225,10 @@ public class DeviceClient extends AbstractClient {
 	 * @return Whether the send was successful.
 	 */	
 	public boolean publishEvent(String event, Object data, int qos) {
-		if (!isConnected()) {
+		if (!isConnected() && !isAutomaticReconnect()) {
 			return false;
 		}
+		
 		final String METHOD = "publishEvent(2)";
 		JsonObject payload = new JsonObject();
 		
@@ -252,7 +253,11 @@ public class DeviceClient extends AbstractClient {
 		msg.setRetained(false);
 		
 		try {
-			mqttAsyncClient.publish(topic, msg).waitForCompletion();
+			if (isConnected() && !isAutomaticReconnect()) {
+				mqttAsyncClient.publish(topic, msg).waitForCompletion();
+			} else {
+				mqttAsyncClient.publish(topic, msg);
+			}
 		} catch (MqttPersistenceException e) {
 			e.printStackTrace();
 			return false;

--- a/src/main/java/com/ibm/iotf/client/gateway/GatewayClient.java
+++ b/src/main/java/com/ibm/iotf/client/gateway/GatewayClient.java
@@ -364,7 +364,7 @@ public class GatewayClient extends AbstractClient implements MqttCallbackExtende
 	 * @return Whether the send was successful.
 	 */
 	public boolean publishDeviceEvent(String deviceType, String deviceId, String event, Object data, int qos) {
-		if (!isConnected()) {
+		if (!isConnected() && !isAutomaticReconnect()) {
 			return false;
 		}
 		final String METHOD = "publishEvent(5)";
@@ -386,7 +386,11 @@ public class GatewayClient extends AbstractClient implements MqttCallbackExtende
 		msg.setRetained(false);
 		
 		try {
-			mqttAsyncClient.publish(topic, msg).waitForCompletion();
+			if (isConnected() && !isAutomaticReconnect()) {
+				mqttAsyncClient.publish(topic, msg).waitForCompletion();
+			} else {
+				mqttAsyncClient.publish(topic, msg);
+			}
 		} catch (MqttPersistenceException e) {
 			e.printStackTrace();
 			return false;

--- a/src/main/java/com/ibm/iotf/devicemgmt/device/ManagedDevice.java
+++ b/src/main/java/com/ibm/iotf/devicemgmt/device/ManagedDevice.java
@@ -841,6 +841,11 @@ public class ManagedDevice extends DeviceClient implements IMqttMessageListener,
 	@Override
 	protected void reconnect() {
 		String METHOD = "reconnect";
+		
+		if (this.isAutomaticReconnect()) {
+			LoggerUtility.log(Level.INFO, CLASS_NAME, METHOD, "Automatic Reconnect is already active for this client.");
+			return;
+		}
 
 		IMqttDeliveryToken[] tokens = this.mqttAsyncClient.getPendingDeliveryTokens();
 		try {


### PR DESCRIPTION
MQTT client auto-reconnect and offline buffering feature should be made available to customers of Watson IoT Platform.  To enable the feature, set these 2 properties:
Automatic-Reconnect=true (default is false)
Disconnected-Buffer-Size=1000 (default is 5000 messages)

For future consideration, I think we should not use waitForCompletion() without a timeout value.  If no timeout is specified, the application will be blocked.

This effectively addresses this issue : https://github.com/ibm-watson-iot/iot-java/issues/55
