### PR TITLE
Fixed Null pointer exception in getDeviceManagementRequest

### DIFF
--- a/src/main/java/com/ibm/iotf/client/IoTFCReSTException.java
+++ b/src/main/java/com/ibm/iotf/client/IoTFCReSTException.java
@@ -39,6 +39,9 @@ public class IoTFCReSTException extends Exception {
 	public static final String HTTP_ADD_DM_EXTENSION_ERR_500 =
 			"Internal server error";
 	public static final String HTTP_INITIATE_DM_REQUEST_ERR_500 = HTTP_ERR_500;
+	public static final String HTTP_GET_DM_REQUEST_ERR_404 =
+			"Request status not found";
+	public static final String HTTP_GET_DM_REQUEST_ERR_500 = HTTP_ERR_500;
 	
 	private String method = null;
 	private String url = null;


### PR DESCRIPTION
Response is only available for HTTP return code 200.

In this pull request:
- Define HTTP codes in IoTFCReSTException class
- Check for HTTP code (200) before parsing the response
- For other error codes, construct IoTFCReSTException object with correct code and message

Signed-off-by: miketran78727 <miketran@us.ibm.com>