### PR TITLE
Fix for issues 64, 81 and 82

### DIFF
--- a/src/main/java/com/ibm/iotf/client/IoTFCReSTException.java
+++ b/src/main/java/com/ibm/iotf/client/IoTFCReSTException.java
@@ -38,6 +38,10 @@ public class IoTFCReSTException extends Exception {
 			"Conflict";
 	public static final String HTTP_ADD_DM_EXTENSION_ERR_500 =
 			"Internal server error";
+	public static final String HTTP_INITIATE_DM_REQUEST_ERR_400 = "The request is invalid";
+	public static final String HTTP_INITIATE_DM_REQUEST_ERR_401 = "The authentication token is empty or invalid";
+	public static final String HTTP_INITIATE_DM_REQUEST_ERR_403 = "One or more of the devices does not support the requested action";
+	public static final String HTTP_INITIATE_DM_REQUEST_ERR_404 = "One or more of the devices does not exist";
 	public static final String HTTP_INITIATE_DM_REQUEST_ERR_500 = HTTP_ERR_500;
 	public static final String HTTP_GET_DM_REQUEST_ERR_404 =
 			"Request status not found";

--- a/src/main/java/com/ibm/iotf/client/Message.java
+++ b/src/main/java/com/ibm/iotf/client/Message.java
@@ -70,6 +70,7 @@ public class Message {
 			} else {
 				timestamp = DateTime.now();
 			}
+			this.payload = payloadJson;
 		} catch (JsonSyntaxException e) {
 			LoggerUtility.log(Level.WARNING, CLASS_NAME, METHOD, "JsonSyntaxException thrown", e);
 		} catch (JsonParseException jpe) {
@@ -103,6 +104,7 @@ public class Message {
 				} else {
 					timestamp = DateTime.now();
 				}
+				this.payload = payloadJson;
 			} catch (JsonSyntaxException e) {
 				LoggerUtility.warn(CLASS_NAME, METHOD, "JsonSyntaxException thrown");
 			} catch (JsonParseException jpe) {

--- a/src/main/java/com/ibm/iotf/client/api/APIClient.java
+++ b/src/main/java/com/ibm/iotf/client/api/APIClient.java
@@ -2602,6 +2602,18 @@ public class APIClient {
 				String result = this.readContent(response, METHOD);
 				jsonResponse = new JsonParser().parse(result);
 				break;
+			case 400:
+				ex = new IoTFCReSTException(method, sb.toString(), request.toString(), code, IoTFCReSTException.HTTP_INITIATE_DM_REQUEST_ERR_400, null);
+				break;
+			case 401:
+				ex = new IoTFCReSTException(method, sb.toString(), request.toString(), code, IoTFCReSTException.HTTP_INITIATE_DM_REQUEST_ERR_401, null);
+				break;
+			case 403:
+				ex = new IoTFCReSTException(method, sb.toString(), request.toString(), code, IoTFCReSTException.HTTP_INITIATE_DM_REQUEST_ERR_403, null);
+				break;
+			case 404:
+				ex = new IoTFCReSTException(method, sb.toString(), request.toString(), code, IoTFCReSTException.HTTP_INITIATE_DM_REQUEST_ERR_404, null);
+				break;
 			case 500:
 				ex = new IoTFCReSTException(method, sb.toString(), request.toString(), code, IoTFCReSTException.HTTP_INITIATE_DM_REQUEST_ERR_500, null);
 				break;

--- a/src/main/java/com/ibm/iotf/client/gateway/GatewayClient.java
+++ b/src/main/java/com/ibm/iotf/client/gateway/GatewayClient.java
@@ -177,9 +177,16 @@ public class GatewayClient extends AbstractClient implements MqttCallbackExtende
 		String id;
 		id = options.getProperty("Gateway-ID");
 		if(id == null) {
-			return getDeviceId();
+			return super.getDeviceId();
 		}
 		return trimedValue(id);
+	}
+	
+	/**
+	 * Returns the Gateway ID
+	 */
+	public String getDeviceId() {
+		return this.getGWDeviceId();
 	}
 	
 	public String getGWDeviceType() {


### PR DESCRIPTION
This pull request includes fixes for the following issues,

1. https://github.com/ibm-watson-iot/iot-java/issues/82 - GatewayClient.getDeviceId() returns null when Gateway-ID key is used 
2. https://github.com/ibm-watson-iot/iot-java/issues/81 - device.Command.getData() returns byte[] for json cmd format 
3. https://github.com/ibm-watson-iot/iot-java/issues/64 - Correct exception message for error code 403 
