### PR TITLE
Pick up Paho Java client library 1.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1</version>
         </dependency>
         <dependency>
             <groupId>commons-net</groupId>


### PR DESCRIPTION
The Paho client library service release 1.1.1 is now available.  This Paho service release contains several important bug fixes: https://github.com/eclipse/paho.mqtt.java/milestone/6?closed=1 
Signed-off-by: miketran <miketran@us.ibm.com>