### PR TITLE
Add LogicalInterface and PhysicalInterface API calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,11 @@
             <artifactId>joda-time</artifactId>
             <version>2.9.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk16</artifactId>
+            <version>1.45</version>
+        </dependency>
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,11 +137,11 @@
             <version>1.45</version>
         </dependency>
 
-		<dependency>
-    		<groupId>org.apache.httpcomponents</groupId>
-    		<artifactId>httpmime</artifactId>
-    		<version>4.3.1</version>
-		</dependency>
+	<dependency>
+    	    <groupId>org.apache.httpcomponents</groupId>
+    	    <artifactId>httpmime</artifactId>
+    	    <version>4.3.1</version>
+	</dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/ibm/iotf/client/IoTFCReSTException.java
+++ b/src/main/java/com/ibm/iotf/client/IoTFCReSTException.java
@@ -52,6 +52,11 @@ public class IoTFCReSTException extends Exception {
 	public static final String HTTP_ADD_LOGICAL_INTERFACE_ERR_401 = HTTP_ADD_DEVICE_ERR_401;
 	public static final String HTTP_ADD_LOGICAL_INTERFACE_ERR_403 = "The authentication method is invalid or the API key used does not exist";
 	public static final String HTTP_ADD_LOGICAL_INTERFACE_ERR_500 = HTTP_ERR_500;
+		
+	public static final String HTTP_ADD_PHYSICAL_INTERFACE_ERR_400 = HTTP_ADD_DEVICE_ERR_400;
+	public static final String HTTP_ADD_PHYSICAL_INTERFACE_ERR_401 = HTTP_ADD_DEVICE_ERR_401;
+	public static final String HTTP_ADD_PHYSICAL_INTERFACE_ERR_403 = "The authentication method is invalid or the API key used does not exist";
+	public static final String HTTP_ADD_PHYSICAL_INTERFACE_ERR_500 = HTTP_ERR_500;
 	
 	private String method = null;
 	private String url = null;

--- a/src/main/java/com/ibm/iotf/client/IoTFCReSTException.java
+++ b/src/main/java/com/ibm/iotf/client/IoTFCReSTException.java
@@ -57,7 +57,12 @@ public class IoTFCReSTException extends Exception {
 	public static final String HTTP_ADD_PHYSICAL_INTERFACE_ERR_401 = HTTP_ADD_DEVICE_ERR_401;
 	public static final String HTTP_ADD_PHYSICAL_INTERFACE_ERR_403 = "The authentication method is invalid or the API key used does not exist";
 	public static final String HTTP_ADD_PHYSICAL_INTERFACE_ERR_500 = HTTP_ERR_500;
-	
+
+	public static final String HTTP_ADD_DRAFT_EVENT_TYPE_ERR_400 = HTTP_ADD_DEVICE_ERR_400;
+	public static final String HTTP_ADD_DRAFT_EVENT_TYPE_ERR_401 = HTTP_ADD_DEVICE_ERR_401;
+	public static final String HTTP_ADD_DRAFT_EVENT_TYPE_ERR_403 = "The authentication method is invalid or the API key used does not exist";
+	public static final String HTTP_ADD_DRAFT_EVENT_TYPE_ERR_500 = HTTP_ERR_500;
+		
 	private String method = null;
 	private String url = null;
 	private int httpCode;

--- a/src/main/java/com/ibm/iotf/client/IoTFCReSTException.java
+++ b/src/main/java/com/ibm/iotf/client/IoTFCReSTException.java
@@ -47,7 +47,11 @@ public class IoTFCReSTException extends Exception {
 	public static final String HTTP_INITIATE_DM_REQUEST_ERR_401 = HTTP_ADD_DEVICE_ERR_401;
 	public static final String HTTP_INITIATE_DM_REQUEST_ERR_403 = "One or more of the devices does not support the requested action";
 	public static final String HTTP_INITIATE_DM_REQUEST_ERR_404 = "One or more of the devices does not exist";
-	 	
+	
+	public static final String HTTP_ADD_LOGICAL_INTERFACE_ERR_400 = HTTP_ADD_DEVICE_ERR_400;
+	public static final String HTTP_ADD_LOGICAL_INTERFACE_ERR_401 = HTTP_ADD_DEVICE_ERR_401;
+	public static final String HTTP_ADD_LOGICAL_INTERFACE_ERR_403 = "The authentication method is invalid or the API key used does not exist";
+	public static final String HTTP_ADD_LOGICAL_INTERFACE_ERR_500 = HTTP_ERR_500;
 	
 	private String method = null;
 	private String url = null;

--- a/src/main/java/com/ibm/iotf/client/api/APIClient.java
+++ b/src/main/java/com/ibm/iotf/client/api/APIClient.java
@@ -4105,7 +4105,7 @@ public class APIClient {
 	 *  
 	 * @throws IoTFCReSTException Failure in retrieving draft logical interface request status
 	 */
-	public JsonObject getDraftLogicalInterfaces(String logicalInterfaceId, List<NameValuePair> parameters) throws IoTFCReSTException {
+	public JsonObject getDraftLogicalInterfaces(List<NameValuePair> parameters) throws IoTFCReSTException {
 		
 		final String METHOD = "getDraftLogicalInterfaces";
 		/**
@@ -4158,7 +4158,7 @@ public class APIClient {
 	 *  
 	 * @throws IoTFCReSTException Failure in retrieving active logical interface request status
 	 */
-	public JsonObject getActiveLogicalInterfaces(String logicalInterfaceId, List<NameValuePair> parameters) throws IoTFCReSTException {
+	public JsonObject getActiveLogicalInterfaces(List<NameValuePair> parameters) throws IoTFCReSTException {
 		
 		final String METHOD = "getActiveLogicalInterfaces";
 		/**

--- a/src/main/java/com/ibm/iotf/client/api/APIClient.java
+++ b/src/main/java/com/ibm/iotf/client/api/APIClient.java
@@ -4855,4 +4855,818 @@ public class APIClient {
 		return null;
 	}
 	
+
+	/**
+	 * Get the state for the device with the specified id
+	 * 
+	 * @param typeId String containing the Device Type Id.
+	 * 
+	 * @param deviceId String containing the Device Id.
+	 * 
+	 * @param logicalInterfaceId String containing the Logical Interface Id.
+	 * 
+	 * @return JSON response containing current state of the device with the specified id
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving current state of the device with the specified id
+	 */
+	public JsonObject getDeviceState(String typeId, String deviceId, String logicalInterfaceId) throws IoTFCReSTException {
+		
+		final String METHOD = "getDeviceState";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/device/types/").
+		   append(typeId).
+		   append("/devices/").
+		   append(deviceId).
+		   append("/state/").
+		   append(logicalInterfaceId);
+		
+		int code = 0;
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect("get", sb.toString(), null, null);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving current state of the device with the specified id "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		if (code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (invalid query parameter, invalid query parameter value)");
+		} else if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if (code == 404) {
+			throw new IoTFCReSTException(code, "An active device type, device or logical interface with the specified ids do not exist");
+		} else if(code == 500) {
+			throw new IoTFCReSTException(code, "Unexpected error", jsonResponse);
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+
+	
+	/**
+	 * Get list of all draft event types
+	 * 
+	 * @param parameters list of query parameters that controls the output.
+	 * 
+	 * @return JSON response containing list of all draft event types
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving draft event types
+	 */
+	public JsonObject getDraftEventTypes(List<NameValuePair> parameters) throws IoTFCReSTException {
+		
+		final String METHOD = "getDraftEventTypes";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/draft/event/types/");
+		
+		int code = 0;
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect("get", sb.toString(), null, parameters);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving list of draft event types "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		if (code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (invalid query parameter, invalid query parameter value)");
+		} else if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if(code == 500) {
+			throw new IoTFCReSTException(code, "Unexpected error", jsonResponse);
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+
+	
+	/**
+	 * Adds draft event type for an organization in Watson IoT Platform.
+	 * 
+	 * @param draftEventType String in the form of JSON containing the event.
+	 * 
+	 * @return If successful, JsonObject response from Watson IoT Platform.
+	 * 
+	 * @throws IoTFCReSTException if failed.
+	 * 
+	 * @see IoTFCReSTException
+	 */
+	public JsonObject addEventToPhysicalInterface(String draftEventType) throws IoTFCReSTException {
+		final String METHOD = "addEventToPhysicalInterface";
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		int code = 0;
+		String method = "post";
+		try {
+			StringBuilder sb = new StringBuilder("https://");
+			sb.append(orgId).
+			   append('.').
+			   append(this.domain).append(BASIC_API_V0002_URL).
+			   append("/draft/event/types");
+			response = connect(method, sb.toString(), draftEventType, null);
+			code = response.getStatusLine().getStatusCode();
+			if (code == 201 || code == 400 || code == 401 || code == 403 || code == 500) {
+				String result = this.readContent(response, METHOD);
+				jsonResponse = new JsonParser().parse(result);
+				if (code == 201) {
+					//Success
+					return jsonResponse.getAsJsonObject();
+				} else {
+					String reason = null;
+					switch (code) {
+					case 400:
+						reason = IoTFCReSTException.HTTP_ADD_DRAFT_EVENT_TYPE_ERR_400;
+						break;
+					case 401:
+						reason = IoTFCReSTException.HTTP_ADD_DRAFT_EVENT_TYPE_ERR_401;
+						break;
+					case 403:
+						reason = IoTFCReSTException.HTTP_ADD_DRAFT_EVENT_TYPE_ERR_403;
+						break;
+					case 500:
+						reason = IoTFCReSTException.HTTP_ADD_DRAFT_EVENT_TYPE_ERR_500;
+						break;
+					}
+					throw new IoTFCReSTException(method, sb.toString(), draftEventType, code, reason, jsonResponse);
+				}
+			} else {
+				throw new IoTFCReSTException(code, "Unexpected error");
+			}
+		} catch (IoTFCReSTException e) {
+			throw e;
+		} catch (Exception e) {
+			// This includes JsonSyntaxException
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in adding draft event type to an organization in Watson IoT Platform "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+	}
+	
+	
+	/**
+	 * Removes a draft event type created in an organization in Watson IoT Platform.
+	 * 
+	 * @param eventTypeId String to be deleted from IBM Watson IoT Platform
+	 *   
+	 * <a href="https://docs.internetofthings.ibmcloud.com/swagger/v0002.html#!/Physical_Interface/delete_physical_interface_Id">link</a> 
+	 * for more information about the schema to be used
+	 * 
+	 * @return boolean object containing the response of the deletion operation.
+	 *  
+	 * @throws IoTFCReSTException Failure in deleting the draft event type
+	 */
+
+	public boolean deleteDraftEventType(String eventTypeId) throws IoTFCReSTException {
+		final String METHOD = "deleteDraftEventType";
+		/**
+		 * Form the url based on this swagger documentation
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/draft/event/types/").
+		   append(eventTypeId);
+		
+		int code = 0;
+		HttpResponse response = null;
+		String method = "delete";
+		try {
+			response = connect(method, sb.toString(), null, null);
+			code = response.getStatusLine().getStatusCode();
+			if(code == 204) {
+				return true;
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in removing the event from an organization in atson IoT Platform "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		
+		if(code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (invalid resource id specified in the path)");
+		} if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if(code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if (code == 404) {
+			throw new IoTFCReSTException(code, "A physical interface with the specified id does not exist");
+		} else if (code == 500) {
+			throw new IoTFCReSTException(500, "Unexpected error");
+		}
+		throwException(response, METHOD);
+		return false;
+	}
+	
+	
+	/**
+	 * Get draft event Type
+	 * 
+	 * @param eventTypeId String containing the Event Type Id.
+	 * 
+	 * @return JSON response containing the draft event type with the specified id
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving the draft event type with the specified id
+	 */
+	public JsonObject getDraftEventType(String eventTypeId) throws IoTFCReSTException {
+		
+		final String METHOD = "getDraftEventType";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/draft/event/types/").
+		   append(eventTypeId);
+		
+		int code = 0;
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect("get", sb.toString(), null, null);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving the draft event type with the specified id "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		if (code == 304) {
+			throw new IoTFCReSTException(code, "The state of the event type has not been modified (response to a conditional GET)");
+		} if (code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (invalid resource id specified in the path)");
+		} else if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if (code == 404) {
+			throw new IoTFCReSTException(code, "An event type with the specified id does not exist");
+		} else if(code == 500) {
+			throw new IoTFCReSTException(code, "Unexpected error", jsonResponse);
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+
+	
+	/**
+	 * Updates draft event type	 
+	 *   
+	 * @param eventTypeId String which contains draft event type id to be retrieved
+	 * 
+	 * @param draftEventType String which contains the Event Type in JSON format
+     *
+	 * <p> Refer to the
+	 * <a href="https://docs.internetofthings.ibmcloud.com/swagger/v0002.html#!/Devices/put_device_types_typeId_devices_deviceId_location">link</a>
+	 * for more information about the JSON format</p>.
+	 *   
+	 * @return A JSON response containing the status of the update operation.
+	 * 
+	 * @throws IoTFCReSTException Failure in updating the device location
+	 */
+	public JsonObject updateDraftEventType(String eventTypeId, String draftEventType) throws IoTFCReSTException {
+		final String METHOD = "updateDraftEventType";
+		/**
+		 * Form the url based on this swagger documentation
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/draft/event/types/").
+		   append(eventTypeId);
+		
+		int code = 0;
+		JsonElement jsonResponse = null;
+		HttpResponse response = null;
+		String method = "put";
+		try {
+			response = connect(method, sb.toString(), draftEventType, null);
+			code = response.getStatusLine().getStatusCode();
+			if(code == 200 || code == 409) {
+				String result = this.readContent(response, METHOD);
+				jsonResponse = new JsonParser().parse(result);
+				if(code == 200) {
+					return jsonResponse.getAsJsonObject();
+				}
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in updating the draft event type "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		
+		if(code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (Invalid resource id specified in the path, no body, invalid JSON, unexpected key, bad value)");
+		} else if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if(code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if(code == 404) {
+			throw new IoTFCReSTException(code, "An Event Type with the specified id does not exist");
+		} else if(code == 412) {
+			throw new IoTFCReSTException(code, "The state of the event type has been modified since the client retrieved "
+					+ "its representation (response to a conditional PUT)");
+		} else if (code == 500) {		
+			throw new IoTFCReSTException(500, "Unexpected error");
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+	
+		
+	/**
+	 * Get list of all active event types
+	 * 
+	 * @param parameters list of query parameters that controls the output.
+	 * 
+	 * @return JSON response containing list of all active event types
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving active event types
+	 */
+	public JsonObject getActiveEventTypes(List<NameValuePair> parameters) throws IoTFCReSTException {
+		
+		final String METHOD = "getActiveEventTypes";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/event/types/");
+		
+		int code = 0;
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect("get", sb.toString(), null, parameters);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving list of active event types "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		if (code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (invalid query parameter, invalid query parameter value)");
+		} else if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if(code == 500) {
+			throw new IoTFCReSTException(code, "Unexpected error", jsonResponse);
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+
+
+	/**
+	 * Get active event Type
+	 * 
+	 * @param eventTypeId String containing the active Event Type Id.
+	 * 
+	 * @return JSON response containing the active event type with the specified id
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving the active event type with the specified id
+	 */
+	public JsonObject getActiveEventType(String eventTypeId) throws IoTFCReSTException {
+		
+		final String METHOD = "getActiveEventType";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/event/types/").
+		   append(eventTypeId);
+		
+		int code = 0;
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect("get", sb.toString(), null, null);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving the active event type with the specified id "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		if (code == 304) {
+			throw new IoTFCReSTException(code, "The state of the event type has not been modified (response to a conditional GET)");
+		} if (code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (invalid resource id specified in the path)");
+		} else if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if (code == 404) {
+			throw new IoTFCReSTException(code, "An event type with the specified id does not exist");
+		} else if(code == 500) {
+			throw new IoTFCReSTException(code, "Unexpected error", jsonResponse);
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+		
+	/**
+	 * Get list of all device types
+	 * 
+	 * @param parameters list of query parameters that controls the output.
+	 * 
+	 * @return JSON response containing list of all device types
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving list of all device types
+	 */
+	public JsonObject getDeviceTypes(List<NameValuePair> parameters) throws IoTFCReSTException {
+		
+		final String METHOD = "getDeviceTypes";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/device/types/");
+		
+		int code = 0;
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect("get", sb.toString(), null, parameters);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving list of all device types "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		if (code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (invalid query parameter, invalid query parameter value)");
+		} else if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if(code == 500) {
+			throw new IoTFCReSTException(code, "Unexpected error", jsonResponse);
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+
+	
+	/**
+	 * Perform operation against Device Type
+	 *  
+	 * @param typeId String which contains the device type id
+	 * 
+	 * @param deviceTypeOperation String contains the operation in JSON format
+	 * 
+	 * <p> Refer to the <a href="https://docs.internetofthings.ibmcloud.com/apis/swagger/v0002/state-mgmt.html#!/Logical_Interfaces/patch_logicalinterfaces_logicalInterfaceId">link</a>
+	 * for more information about the JSON format</p>.
+	 *   
+	 * @return A JSON response containing the status of the patch operation.
+	 * 
+	 * @throws IoTFCReSTException Failure in updating the device type operation
+	 */
+	public JsonObject performOperationAgainstDeviceType(String typeId, String deviceTypeOperation) throws IoTFCReSTException {
+		final String METHOD = "performOperationAgainstDeviceType";
+		/**
+		 * Form the url based on this swagger documentation
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/device/types/").
+		   append(typeId);
+		
+		int code = 0;
+		JsonElement jsonResponse = null;
+		HttpResponse response = null;
+		String method = "patch";
+		try {
+			response = connect(method, sb.toString(), deviceTypeOperation, null);
+			code = response.getStatusLine().getStatusCode();
+			if(code == 200 || code == 202) {
+				String result = this.readContent(response, METHOD);
+				jsonResponse = new JsonParser().parse(result);
+				if(code == 200) {
+					return jsonResponse.getAsJsonObject();
+				}
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in updating the device type operation "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		
+		if(code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (Invalid resource id specified in the path, no body, invalid JSON, unexpected key, bad value)");
+		} else if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if(code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if(code == 404) {
+			throw new IoTFCReSTException(code, "The device type does not exist");
+		} else if(code == 409) {
+			throw new IoTFCReSTException(code, "The deactivate operation failed because there is no active configuration associated with the device type ");
+		} else if (code == 500) {		
+			throw new IoTFCReSTException(500, "Unexpected error");
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+	
+
+	/**
+	 * Get active logical interfaces associated with a device type
+	 * 
+	 * @param typeId String containing the device Type Id.
+	 * 
+	 * @return JSON response containing the list of active logical interfaces with the specified device type id
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving the list of active logical interfaces with the specified device type id
+	 */
+	public JsonObject getActiveLogicalInterfacesForDeviceType(String typeId) throws IoTFCReSTException {
+		
+		final String METHOD = "getActiveLogicalInterfacesForDeviceType";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/device/types/").
+		   append(typeId).
+		   append("/logicalinterfaces");
+		
+		int code = 0;
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect("get", sb.toString(), null, null);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving the list of active logical interfaces with the specified device type id "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if (code == 404) {
+			throw new IoTFCReSTException(code, "A device type with the specified id does not exist");
+		} else if(code == 500) {
+			throw new IoTFCReSTException(code, "Unexpected error", jsonResponse);
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+	
+
+	/**
+	 * Get the list of active property mappings for a device type
+	 * 
+	 * @param typeId String containing the device Type Id.
+	 * 
+	 * @return JSON response containing the list of active property mappings for a device type
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving the list of active property mappings for a device type
+	 */
+	public JsonObject getActivePropertyMappingsForDeviceType(String typeId) throws IoTFCReSTException {
+		
+		final String METHOD = "getActivePropertyMappingsForDeviceType";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/device/types/").
+		   append(typeId).
+		   append("/mappings");
+		
+		int code = 0;
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect("get", sb.toString(), null, null);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving the list of active property mappings for a device type "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if (code == 404) {
+			throw new IoTFCReSTException(code, "A device type with the specified id does not exist");
+		} else if(code == 500) {
+			throw new IoTFCReSTException(code, "Unexpected error", jsonResponse);
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+
+
+	/**
+	 * Get the list of active property mappings for a logical interface of a given device type
+	 * 
+	 * @param typeId String containing the device Type Id.
+	 * 
+	 * @param logicalInterfaceId String containing the logical interface Id
+	 * 
+	 * @return JSON response containing the list of active property mappings for a logical interface of a given device type
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving the list of active property mappings for a logical interface of a given device type
+	 */
+	public JsonObject getActivePropertyMappingsForLogicalInterfaceOfDeviceType(String typeId, String logicalInterfaceId) throws IoTFCReSTException {
+		
+		final String METHOD = "getActivePropertyMappingsForLogicalInterfaceOfDeviceType";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/device/types/").
+		   append(typeId).
+		   append("/mappings/").
+		   append(logicalInterfaceId);
+		
+		int code = 0;
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect("get", sb.toString(), null, null);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving the list of active property mappings for a logical interface of a given device type "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if (code == 404) {
+			throw new IoTFCReSTException(code, "A device type with the specified id does not exist or a property mapping for the specified logical interface id does not exist");
+		} else if(code == 500) {
+			throw new IoTFCReSTException(code, "Unexpected error", jsonResponse);
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+
+	
+	/**
+	 * Get active physical interface for a given device type
+	 * 
+	 * @param typeId String containing the device Type Id.
+	 * 
+	 * @return JSON response containing active physical interface for a given device type
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving the active physical interface for a given device type
+	 */
+	public JsonObject getActivePhysicalInterfaceForDeviceType(String typeId) throws IoTFCReSTException {
+		
+		final String METHOD = "getActivePhysicalInterfaceForDeviceType";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/device/types/").
+		   append(typeId).
+		   append("/physicalinterface");
+		
+		int code = 0;
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect("get", sb.toString(), null, null);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving the active physical interface for a given device type "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if (code == 404) {
+			throw new IoTFCReSTException(code, "A device type with the specified id does not exist or has no active physical interface associated with it");
+		} else if(code == 500) {
+			throw new IoTFCReSTException(code, "Unexpected error", jsonResponse);
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+
 }

--- a/src/main/java/com/ibm/iotf/client/api/APIClient.java
+++ b/src/main/java/com/ibm/iotf/client/api/APIClient.java
@@ -3678,12 +3678,13 @@ public class APIClient {
 	/**
 	 * Create a draft logical interface.
 	 * 
-	 * @param request JSON string containing the draft logical interface.
+	 * @param draftLogicalInterface JSON string containing the draft logical interface.
+	 * 
 	 * @return If successful, JsonObject response from Watson IoT Platform.
 	 * @throws IoTFCReSTException if failed.
 	 * @see IoTFCReSTException
 	 */
-	public JsonObject addDraftLogicalInterface(String request) throws IoTFCReSTException {
+	public JsonObject addDraftLogicalInterface(String draftLogicalInterface) throws IoTFCReSTException {
 		final String METHOD = "addDraftLogicalInterface";
 		HttpResponse response = null;
 		JsonElement jsonResponse = null;
@@ -3695,7 +3696,7 @@ public class APIClient {
 			   append('.').
 			   append(this.domain).append(BASIC_API_V0002_URL).
 			   append("/draft/logicalinterfaces");
-			response = connect(method, sb.toString(), request, null);
+			response = connect(method, sb.toString(), draftLogicalInterface, null);
 			code = response.getStatusLine().getStatusCode();
 			if (code == 201 || code == 400 || code == 401 || code == 403 || code == 500) {
 				String result = this.readContent(response, METHOD);
@@ -3719,7 +3720,7 @@ public class APIClient {
 						reason = IoTFCReSTException.HTTP_ADD_LOGICAL_INTERFACE_ERR_500;
 						break;
 					}
-					throw new IoTFCReSTException(method, sb.toString(), request, code, reason, jsonResponse);
+					throw new IoTFCReSTException(method, sb.toString(), draftLogicalInterface, code, reason, jsonResponse);
 				}
 			} else {
 				throw new IoTFCReSTException(code, "Unexpected error");
@@ -3911,6 +3912,8 @@ public class APIClient {
 	 * Updates the location information for a device. If no date is supplied, the entry is added with the current date and time.
 	 *  
 	 * @param logicalInterfaceId String which contains draft logical interface id to be retrieved
+	 * 
+	 * @param draftLogicalInterface String which contains the LogicalInterface in JSON format
      *
 	 * <p> Refer to the
 	 * <a href="https://docs.internetofthings.ibmcloud.com/swagger/v0002.html#!/Devices/put_device_types_typeId_devices_deviceId_location">link</a>
@@ -3920,7 +3923,7 @@ public class APIClient {
 	 * 
 	 * @throws IoTFCReSTException Failure in updting the device location
 	 */
-	public JsonObject updateDraftLogicalInterface(String logicalInterfaceId) throws IoTFCReSTException {
+	public JsonObject updateDraftLogicalInterface(String logicalInterfaceId, String draftLogicalInterface) throws IoTFCReSTException {
 		final String METHOD = "updateDraftLogicalInterface";
 		/**
 		 * Form the url based on this swagger documentation
@@ -3937,7 +3940,7 @@ public class APIClient {
 		HttpResponse response = null;
 		String method = "put";
 		try {
-			response = connect(method, sb.toString(), null, null);
+			response = connect(method, sb.toString(), draftLogicalInterface, null);
 			code = response.getStatusLine().getStatusCode();
 			if(code == 200 || code == 409) {
 				String result = this.readContent(response, METHOD);
@@ -3976,6 +3979,7 @@ public class APIClient {
 	 * Perform operation against Draft Logical Interface
 	 *  
 	 * @param logicalInterfaceId String which contains the logical interface id
+	 * @param operation String contains the operation details in JSON format
 	 * <p> Refer to the <a href="https://docs.internetofthings.ibmcloud.com/apis/swagger/v0002/state-mgmt.html#!/Logical_Interfaces/patch_logicalinterfaces_logicalInterfaceId">link</a>
 	 * for more information about the JSON format</p>.
 	 *   
@@ -3983,7 +3987,7 @@ public class APIClient {
 	 * 
 	 * @throws IoTFCReSTException Failure in updating the device location
 	 */
-	public JsonObject performOperationAgainstDraftLogicalInterface(String logicalInterfaceId) throws IoTFCReSTException {
+	public JsonObject performOperationAgainstDraftLogicalInterface(String logicalInterfaceId, String operation) throws IoTFCReSTException {
 		final String METHOD = "performOperationAgainstDraftLogicalInterface";
 		/**
 		 * Form the url based on this swagger documentation
@@ -4000,7 +4004,7 @@ public class APIClient {
 		HttpResponse response = null;
 		String method = "patch";
 		try {
-			response = connect(method, sb.toString(), null, null);
+			response = connect(method, sb.toString(), operation, null);
 			code = response.getStatusLine().getStatusCode();
 			if(code == 200 || code == 202) {
 				String result = this.readContent(response, METHOD);
@@ -4038,6 +4042,9 @@ public class APIClient {
 	 * Perform operation against Logical Interface
 	 *  
 	 * @param logicalInterfaceId String which contains the logical interface id
+	 * 
+	 * @param operation String contains the operation in JSON format
+	 * 
 	 * <p> Refer to the <a href="https://docs.internetofthings.ibmcloud.com/apis/swagger/v0002/state-mgmt.html#!/Logical_Interfaces/patch_logicalinterfaces_logicalInterfaceId">link</a>
 	 * for more information about the JSON format</p>.
 	 *   
@@ -4045,7 +4052,7 @@ public class APIClient {
 	 * 
 	 * @throws IoTFCReSTException Failure in updating the device location
 	 */
-	public JsonObject performOperationAgainstLogicalInterface(String logicalInterfaceId) throws IoTFCReSTException {
+	public JsonObject performOperationAgainstLogicalInterface(String logicalInterfaceId, String operation) throws IoTFCReSTException {
 		final String METHOD = "performOperationAgainstLogicalInterface";
 		/**
 		 * Form the url based on this swagger documentation
@@ -4062,7 +4069,7 @@ public class APIClient {
 		HttpResponse response = null;
 		String method = "patch";
 		try {
-			response = connect(method, sb.toString(), null, null);
+			response = connect(method, sb.toString(), operation, null);
 			code = response.getStatusLine().getStatusCode();
 			if(code == 200 || code == 202) {
 				String result = this.readContent(response, METHOD);
@@ -4201,4 +4208,651 @@ public class APIClient {
 		return null;
 	}
 
+	/**
+	 * Get list of all draft physical interfaces
+	 * 
+	 * @param parameters list of query parameters that controls the output.
+	 * 
+	 * @return JSON response containing list of draft physical interfaces
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving draft physical interface request status
+	 */
+	public JsonObject getDraftPhysicalInterfaces(List<NameValuePair> parameters) throws IoTFCReSTException {
+		
+		final String METHOD = "getDraftPhysicalInterfaces";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/draft/physicalinterfaces/");
+		
+		int code = 0;
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect("get", sb.toString(), null, parameters);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving list of draft physical interfaces "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		if (code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (invalid query parameter, invalid query parameter value)");
+		} else if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if(code == 500) {
+			throw new IoTFCReSTException(code, "Unexpected error", jsonResponse);
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+	
+	
+	/**
+	 * Create a draft physical interface.
+	 * 
+	 * @param draftPhysicalInterface JSON string containing the draft logical interface.
+	 * 
+	 * @return If successful, JsonObject response from Watson IoT Platform.
+	 * @throws IoTFCReSTException if failed.
+	 * @see IoTFCReSTException
+	 */
+	public JsonObject addDraftPhysicalInterface(String draftPhysicalInterface) throws IoTFCReSTException {
+		final String METHOD = "addDraftPhysicalInterface";
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		int code = 0;
+		String method = "post";
+		try {
+			StringBuilder sb = new StringBuilder("https://");
+			sb.append(orgId).
+			   append('.').
+			   append(this.domain).append(BASIC_API_V0002_URL).
+			   append("/draft/physicalinterfaces");
+			response = connect(method, sb.toString(), draftPhysicalInterface, null);
+			code = response.getStatusLine().getStatusCode();
+			if (code == 201 || code == 400 || code == 401 || code == 403 || code == 500) {
+				String result = this.readContent(response, METHOD);
+				jsonResponse = new JsonParser().parse(result);
+				if (code == 201) {
+					//Success
+					return jsonResponse.getAsJsonObject();
+				} else {
+					String reason = null;
+					switch (code) {
+					case 400:
+						reason = IoTFCReSTException.HTTP_ADD_PHYSICAL_INTERFACE_ERR_400;
+						break;
+					case 401:
+						reason = IoTFCReSTException.HTTP_ADD_PHYSICAL_INTERFACE_ERR_401;
+						break;
+					case 403:
+						reason = IoTFCReSTException.HTTP_ADD_PHYSICAL_INTERFACE_ERR_403;
+						break;
+					case 500:
+						reason = IoTFCReSTException.HTTP_ADD_PHYSICAL_INTERFACE_ERR_500;
+						break;
+					}
+					throw new IoTFCReSTException(method, sb.toString(), draftPhysicalInterface, code, reason, jsonResponse);
+				}
+			} else {
+				throw new IoTFCReSTException(code, "Unexpected error");
+			}
+		} catch (IoTFCReSTException e) {
+			throw e;
+		} catch (Exception e) {
+			// This includes JsonSyntaxException
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in adding the Draft Physical Interface "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+	}
+	
+	
+	/**
+	 * Deletes a draft physical interface.
+	 * 
+	 * @param physicalInterfaceId String to be deleted from IBM Watson IoT Platform
+	 *   
+	 * <a href="https://docs.internetofthings.ibmcloud.com/swagger/v0002.html#!/Physical_Interface/delete_physical_interface_Id">link</a> 
+	 * for more information about the schema to be used
+	 * 
+	 * @return boolean object containing the response of deletion operation.
+	 *  
+	 * @throws IoTFCReSTException Failure in deleting the draft physical interface
+	 */
+
+	public boolean deleteDraftPhysicalInterface(String physicalInterfaceId) throws IoTFCReSTException {
+		final String METHOD = "deleteDraftPhysicalInterface";
+		/**
+		 * Form the url based on this swagger documentation
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/draft/physicalinterfaces/").
+		   append(physicalInterfaceId);
+		
+		int code = 0;
+		HttpResponse response = null;
+		String method = "delete";
+		try {
+			response = connect(method, sb.toString(), null, null);
+			code = response.getStatusLine().getStatusCode();
+			if(code == 204) {
+				return true;
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in deleting the Physical Interface "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		
+		if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if(code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if (code == 404) {
+			throw new IoTFCReSTException(code, "A physical interface with the specified id does not exist");
+		} else if(code == 409) {
+			throw new IoTFCReSTException(code, "The physical interface with the specified id is currently being referenced by another object");
+		} else if (code == 500) {
+			throw new IoTFCReSTException(500, "Unexpected error");
+		}
+		throwException(response, METHOD);
+		return false;
+	}
+	
+	
+	/**
+	 * Retrieve the draft physical interface
+	 *
+	 * @param physicalInterfaceId String to be retrieved from IBM Watson IoT Platform
+	 * 
+	 * @return JSON response containing the draft physical interface
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving the draft physical interface
+	 */
+	public JsonObject getDraftPhysicalInterface(String physicalInterfaceId) throws IoTFCReSTException {
+		final String METHOD = "getDraftPhysicalInterface";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/draft/physicalinterfaces/").
+		   append(physicalInterfaceId);
+		
+		int code = 0;
+		String method = "get";
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect(method, sb.toString(), null, null);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving the draft physical interface "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		
+		if (code == 304) {
+			throw new IoTFCReSTException(code, "The state of the physical interface has not been modified (response to a conditional GET)");
+		} else if (code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (invalid resource id specified in the path)");
+		} else if (code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if (code == 404) {
+			throw new IoTFCReSTException(code, "A physical interface with the specified id does not exist");
+		} else if (code == 500) {
+			throw new IoTFCReSTException(500, "Unexpected error");
+		}
+		throw new IoTFCReSTException(code, "", jsonResponse);
+	}
+	
+	/**
+	 * Updates the physical interface	 *  
+	 * @param physicalInterfaceId String which contains draft logical interface id to be retrieved
+	 * 
+	 * @param draftPhysicalInterface String which contains the LogicalInterface in JSON format
+     *
+	 * <p> Refer to the
+	 * <a href="https://docs.internetofthings.ibmcloud.com/swagger/v0002.html#!/Devices/put_device_types_typeId_devices_deviceId_location">link</a>
+	 * for more information about the JSON format</p>.
+	 *   
+	 * @return A JSON response containing the status of the update operation.
+	 * 
+	 * @throws IoTFCReSTException Failure in updting the device location
+	 */
+	public JsonObject updateDraftPhysicalInterface(String physicalInterfaceId, String draftPhysicalInterface) throws IoTFCReSTException {
+		final String METHOD = "updateDraftPhysicalInterface";
+		/**
+		 * Form the url based on this swagger documentation
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/draft/physicalinterfaces/").
+		   append(physicalInterfaceId);
+		
+		int code = 0;
+		JsonElement jsonResponse = null;
+		HttpResponse response = null;
+		String method = "put";
+		try {
+			response = connect(method, sb.toString(), draftPhysicalInterface, null);
+			code = response.getStatusLine().getStatusCode();
+			if(code == 200 || code == 409) {
+				String result = this.readContent(response, METHOD);
+				jsonResponse = new JsonParser().parse(result);
+				if(code == 200) {
+					return jsonResponse.getAsJsonObject();
+				}
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in updating the draft physical interface "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		
+		if(code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (Invalid resource id specified in the path, no body, invalid JSON, unexpected key, bad value)");
+		} else if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if(code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if(code == 404) {
+			throw new IoTFCReSTException(code, "A physical interface with the specified id does not exist");
+		} else if(code == 412) {
+			throw new IoTFCReSTException(code, "The state of the physical interface has been modified since the "
+					+ "client retrieved its representation (response to a conditional PUT)");
+		} else if (code == 500) {		
+			throw new IoTFCReSTException(500, "Unexpected error");
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+	
+	
+	/**
+	 * Adds event to physical interface.
+	 * 
+	 * @param draftPhysicalInterfaceId String containing the draft logical interface.
+	 * 
+	 * @param event String in the form of JSON containing the event.
+	 * 
+	 * @return If successful, JsonObject response from Watson IoT Platform.
+	 * 
+	 * @throws IoTFCReSTException if failed.
+	 * 
+	 * @see IoTFCReSTException
+	 */
+	public JsonObject addEventToPhysicalInterface(String draftPhysicalInterfaceId, String event) throws IoTFCReSTException {
+		final String METHOD = "addDraftPhysicalInterface";
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		int code = 0;
+		String method = "post";
+		try {
+			StringBuilder sb = new StringBuilder("https://");
+			sb.append(orgId).
+			   append('.').
+			   append(this.domain).append(BASIC_API_V0002_URL).
+			   append("/draft/physicalinterfaces/").
+			   append(draftPhysicalInterfaceId).append("/events/");
+			response = connect(method, sb.toString(), event, null);
+			code = response.getStatusLine().getStatusCode();
+			if (code == 201 || code == 400 || code == 401 || code == 403 || code == 500) {
+				String result = this.readContent(response, METHOD);
+				jsonResponse = new JsonParser().parse(result);
+				if (code == 201) {
+					//Success
+					return jsonResponse.getAsJsonObject();
+				} else {
+					String reason = null;
+					switch (code) {
+					case 400:
+						reason = IoTFCReSTException.HTTP_ADD_PHYSICAL_INTERFACE_ERR_400;
+						break;
+					case 401:
+						reason = IoTFCReSTException.HTTP_ADD_PHYSICAL_INTERFACE_ERR_401;
+						break;
+					case 403:
+						reason = IoTFCReSTException.HTTP_ADD_PHYSICAL_INTERFACE_ERR_403;
+						break;
+					case 500:
+						reason = IoTFCReSTException.HTTP_ADD_PHYSICAL_INTERFACE_ERR_500;
+						break;
+					}
+					throw new IoTFCReSTException(method, sb.toString(), draftPhysicalInterfaceId, code, reason, jsonResponse);
+				}
+			} else {
+				throw new IoTFCReSTException(code, "Unexpected error");
+			}
+		} catch (IoTFCReSTException e) {
+			throw e;
+		} catch (Exception e) {
+			// This includes JsonSyntaxException
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in adding event to the Draft Physical Interface "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+	}
+
+
+	/**
+	 * Get list of all events mapped to draft physical interface
+	 * 
+	 * @param draftPhysicalInterfaceId String containing the Draft Physical Interface Id.
+	 * 
+	 * @return JSON response containing list of events
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving events mapped to a Draft Physical Interface
+	 */
+	public JsonObject getEventsMappedToDraftPhysicalInterface(String draftPhysicalInterfaceId) throws IoTFCReSTException {
+		
+		final String METHOD = "getEventsMappedToDraftPhysicalInterface";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/draft/physicalinterfaces/").
+		   append(draftPhysicalInterfaceId).
+		   append("/events/");
+		
+		int code = 0;
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect("get", sb.toString(), null, null);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving list of events associated with draft physical interface "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		if (code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (invalid query parameter, invalid query parameter value)");
+		} else if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if (code == 404) {
+			throw new IoTFCReSTException(code, "A physical interface with the specified id does not exist");
+		} else if(code == 500) {
+			throw new IoTFCReSTException(code, "Unexpected error", jsonResponse);
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+	
+	
+	/**
+	 * Removes an event mapped to draft physical interface.
+	 * 
+	 * @param draftPhysicalInterfaceId String Draft Physical Interface from where an event needs to be deleted
+	 * 
+	 * @param eventId String to be deleted from IBM Watson IoT Platform
+	 *   
+	 * <a href="https://docs.internetofthings.ibmcloud.com/swagger/v0002.html#!/Physical_Interface/delete_physical_interface_Id">link</a> 
+	 * for more information about the schema to be used
+	 * 
+	 * @return boolean object containing the response of the deletion operation.
+	 *  
+	 * @throws IoTFCReSTException Failure in deleting the draft physical interface
+	 */
+
+	public boolean deleteEventMappingFromPhysicalInterface(String draftPhysicalInterfaceId, String eventId) throws IoTFCReSTException {
+		final String METHOD = "deleteDraftPhysicalInterface";
+		/**
+		 * Form the url based on this swagger documentation
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/draft/physicalinterfaces/").
+		   append(draftPhysicalInterfaceId).
+		   append("/events/").
+		   append(eventId);
+		
+		int code = 0;
+		HttpResponse response = null;
+		String method = "delete";
+		try {
+			response = connect(method, sb.toString(), null, null);
+			code = response.getStatusLine().getStatusCode();
+			if(code == 204) {
+				return true;
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in removing the event from the draft Physical Interface "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		
+		if(code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (invalid resource id specified in the path)");
+		} if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if(code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if (code == 404) {
+			throw new IoTFCReSTException(code, "A physical interface with the specified id does not exist");
+		} else if (code == 500) {
+			throw new IoTFCReSTException(500, "Unexpected error");
+		}
+		throwException(response, METHOD);
+		return false;
+	}
+	
+	
+	/**
+	 * Get list of all active physical interfaces
+	 * 
+	 * @param parameters list of query parameters that controls the output.
+	 * 
+	 * @return JSON response containing list of active physical interfaces
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving active physical interface request status
+	 */
+	public JsonObject getActivePhysicalInterfaces(List<NameValuePair> parameters) throws IoTFCReSTException {
+		
+		final String METHOD = "getActivePhysicalInterfaces";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/physicalinterfaces/");
+		
+		int code = 0;
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect("get", sb.toString(), null, parameters);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving list of active physical interfaces "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		if (code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (invalid query parameter, invalid query parameter value)");
+		} else if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if(code == 500) {
+			throw new IoTFCReSTException(code, "Unexpected error", jsonResponse);
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+
+	
+	/**
+	 * Retrieve the active physical interface
+	 *
+	 * @param physicalInterfaceId String to be retrieved from IBM Watson IoT Platform
+	 * 
+	 * @return JSON response containing the active physical interface
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving the active physical interface
+	 */
+	public JsonObject getActivePhysicalInterface(String physicalInterfaceId) throws IoTFCReSTException {
+		final String METHOD = "getActivePhysicalInterface";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/physicalinterfaces/").
+		   append(physicalInterfaceId);
+		
+		int code = 0;
+		String method = "get";
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect(method, sb.toString(), null, null);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving the active logical interface "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		
+		if (code == 304) {
+			throw new IoTFCReSTException(code, "The state of the physical interface has not been modified (response to a conditional GET)");
+		} else if (code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (invalid resource id specified in the path)");
+		} else if (code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if (code == 404) {
+			throw new IoTFCReSTException(code, "A physical interface with the specified id does not exist");
+		} else if (code == 500) {
+			throw new IoTFCReSTException(500, "Unexpected error");
+		}
+		throw new IoTFCReSTException(code, "", jsonResponse);
+	}
+
+
+	/**
+	 * Get list of all events mapped to active physical interface
+	 * 
+	 * @param physicalInterfaceId String containing the Active Physical Interface Id.
+	 * 
+	 * @return JSON response containing list of events
+	 *  
+	 * @throws IoTFCReSTException Failure in retrieving events mapped to an Active Physical Interface
+	 */
+	public JsonObject getEventsMappedToPhysicalInterface(String physicalInterfaceId) throws IoTFCReSTException {
+		
+		final String METHOD = "getEventsMappedToPhysicalInterface";
+		/**
+		 * Form the url based on this swagger documentation
+		 * 
+		 */
+		StringBuilder sb = new StringBuilder("https://");
+		sb.append(orgId).
+		   append('.').
+		   append(this.domain).append(BASIC_API_V0002_URL).
+		   append("/physicalinterfaces/").
+		   append(physicalInterfaceId).
+		   append("/events/");
+		
+		int code = 0;
+		HttpResponse response = null;
+		JsonElement jsonResponse = null;
+		try {
+			response = connect("get", sb.toString(), null, null);
+			code = response.getStatusLine().getStatusCode();
+			String result = this.readContent(response, METHOD);
+			jsonResponse = new JsonParser().parse(result);
+			if(code == 200) {
+				return jsonResponse.getAsJsonObject();
+			}
+		} catch(Exception e) {
+			IoTFCReSTException ex = new IoTFCReSTException("Failure in retrieving list of events associated with active physical interface "
+					+ "::"+e.getMessage());
+			ex.initCause(e);
+			throw ex;
+		}
+		if (code == 400) {
+			throw new IoTFCReSTException(code, "Invalid request (invalid query parameter, invalid query parameter value)");
+		} else if(code == 401) {
+			throw new IoTFCReSTException(code, "The authentication token is empty or invalid");
+		} else if (code == 403) {
+			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist");
+		} else if (code == 404) {
+			throw new IoTFCReSTException(code, "A physical interface with the specified id does not exist");
+		} else if(code == 500) {
+			throw new IoTFCReSTException(code, "Unexpected error", jsonResponse);
+		}
+		throwException(response, METHOD);
+		return null;
+	}
+	
 }

--- a/src/test/java/com/ibm/iotf/client/application/api/DeviceAPIOperationsTest.java
+++ b/src/test/java/com/ibm/iotf/client/application/api/DeviceAPIOperationsTest.java
@@ -410,25 +410,60 @@ public class DeviceAPIOperationsTest extends TestCase {
 			fail("Doesn't throw invild Auth token exception");
 		} catch(IoTFCReSTException e) {}
 		
-		// Wrrong Method
+		// Wrong Method
 		try {
 			apiClientWithWrongKey.getDeviceLocation(DEVICE_TYPE, DEVICE_ID);
 			fail("Doesn't throw invild API Key exception");
 		} catch(IoTFCReSTException e) {}
 		
-		// Wrrong Org
+		// Wrong Org
 		try {
 			apiClientWithWrongOrg.getDeviceLocation(DEVICE_TYPE, DEVICE_ID);
 			fail("Doesn't throw invild ORG exception");
 		} catch(IoTFCReSTException e) {}	
 	}
 	
+	/**
+	 * This sample showcases how to get a device location weather using the Java Client Library.
+	 * @throws IoTFCReSTException
+	 */
+	public void test05getDeviceLocationWeather() throws IoTFCReSTException {
+		try {
+			System.out.println("get device location weather of device --> "+DEVICE_ID);
+			JsonObject response = this.apiClient.getDeviceLocationWeather(DEVICE_TYPE, DEVICE_ID);
+			System.out.println(response);
+		} catch(IoTFCReSTException e) {
+			fail("HttpCode :" + e.getHttpCode() +" ErrorMessage :: "+ e.getMessage());
+			// Print if there is a partial response
+			System.out.println(e.getResponse());
+		}
+		
+		// negative test, it should fail
+		try {
+			apiClientWithWrongToken.getDeviceLocationWeather(DEVICE_TYPE, DEVICE_ID);
+			fail("Doesn't throw invild Auth token exception");
+		} catch(IoTFCReSTException e) {}
+		
+		// Wrong Method
+		try {
+			apiClientWithWrongKey.getDeviceLocationWeather(DEVICE_TYPE, DEVICE_ID);
+			fail("Doesn't throw invild API Key exception");
+		} catch(IoTFCReSTException e) {}
+		
+		// Wrong Org
+		try {
+			apiClientWithWrongOrg.getDeviceLocationWeather(DEVICE_TYPE, DEVICE_ID);
+			fail("Doesn't throw invild ORG exception");
+		} catch(IoTFCReSTException e) {}	
+	}
+	
+	
 	
 	/**
 	 * This sample showcases how to get a management information of a device using the Java Client Library.
 	 * @throws Exception 
 	 */
-	public void test05getDeviceManagementInformation() throws Exception {
+	public void test06getDeviceManagementInformation() throws Exception {
 		
 		/**
 		  * Load device properties
@@ -489,7 +524,7 @@ public class DeviceAPIOperationsTest extends TestCase {
 	 * This sample showcases how to update a device using the Java Client Library.
 	 * @throws IoTFCReSTException
 	 */
-	public void test06updateDevice() throws IoTFCReSTException {
+	public void test07updateDevice() throws IoTFCReSTException {
 		
 		JsonObject updatedMetadata = new JsonObject();
 		
@@ -530,7 +565,7 @@ public class DeviceAPIOperationsTest extends TestCase {
 	 * This sample showcases how to retrieve all the devices in an organization using the Java Client Library.
 	 * @throws IoTFCReSTException
 	 */
-	public void test07getAllDevices() throws IoTFCReSTException {
+	public void test08getAllDevices() throws IoTFCReSTException {
 		System.out.println("Get all devices of device type--> "+DEVICE_TYPE);
 		// Get all the devices of type TestDT
 		ArrayList<NameValuePair> parameters = new ArrayList<NameValuePair>();
@@ -628,4 +663,5 @@ public class DeviceAPIOperationsTest extends TestCase {
 		} catch(IoTFCReSTException e) {}	
 		
 	}
+	
 }

--- a/src/test/java/com/ibm/iotf/client/infomgmt/IMOperationsTests.java
+++ b/src/test/java/com/ibm/iotf/client/infomgmt/IMOperationsTests.java
@@ -1,0 +1,661 @@
+/**
+ *****************************************************************************
+ * Copyright (c) 2017 IBM Corporation and other Contributors.
+
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Amit M Mangalvedkar - Initial Contribution
+ *****************************************************************************
+ */
+
+package com.ibm.iotf.client.infomgmt;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+
+import junit.framework.TestCase;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+
+import com.ibm.iotf.client.IoTFCReSTException;
+import com.ibm.iotf.client.api.APIClient;
+
+/**
+ * This test verifies various bulk ReST operations that can be performed on Watson IoT Platform.
+ *
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class IMOperationsTests extends TestCase {
+	
+	private final static String PROPERTIES_FILE_NAME = "/application.properties";
+	private final static String DEVICE_TYPE = "SampleDT";
+	private final static String DEVICE_ID1 = "Device01";
+	private final static String DEVICE_ID2 = "Device02";
+	
+	private final static String APPLICATION_PROPERTIES_FILE = "/application.properties";
+	
+	private final static String EVENT_SCHEMA1 = "/Users/amitmangalvedkar/Documents/workspace/mars/watsoniot/testlibraries/"
+			+ "iot-sample-java/src/main/resources/tempEventSchema.json";
+	private final static String SCHEMA_NAME1 = "fahrenhietSchema";
+	private final static String SCHEMA_DESCRIPTION1 = "Schema to capture the temperature readings in Fahrenhiet";
+	private final static String SCHEMA_TYPE1 = "json-schema";
+	
+	private final static String EVENT_SCHEMA2 = "/Users/amitmangalvedkar/Documents/workspace/mars/watsoniot/testlibraries/"
+			+ "iot-sample-java/src/main/resources/envSensor.json";
+	private final static String SCHEMA_NAME2 = "celciusSchema";
+	private final static String SCHEMA_DESCRIPTION2 = "Schema to capture the temperature readings in Celcius";
+	private final static String SCHEMA_TYPE2 = "json-schema";
+	
+	private final String EVENT_DESCRIPTION1 = "Native event definition for the MyBulbCo light bulb on event";
+	
+	// Example Json format to add a device
+	/*
+	 * {
+		    "typeId": "SampleDT",
+		    "deviceId": "RasPi100",
+		    "authToken": "password",
+		    "deviceInfo": {
+		        "serialNumber": "10087",
+		        "manufacturer": "IBM",
+		        "model": "7865",
+		        "deviceClass": "A",
+		        "description": "My RasPi01 Device",
+		        "fwVersion": "1.0.0",
+		        "hwVersion": "1.0",
+		        "descriptiveLocation": "EGL C"
+		    },
+		    "location": {
+		        "measuredDateTime": "2015-23-07T11:23:23+00:00"
+		    },
+		    "metadata": {}
+		}
+	 */
+	private final static String deviceToBeAdded1 = "{\"typeId\": \""+ DEVICE_TYPE + "\",\"deviceId\": "
+			+ "\"" + DEVICE_ID1 + "\",\"authToken\": \"password\",\"deviceInfo\": {\"serialNumber\": "
+			+ "\"10087\",\"manufacturer\": \"IBM\",\"model\": \"7865\",\"deviceClass\": "
+			+ "\"A\",\"description\": \"My RasPi01 Device\",\"fwVersion\": \"1.0.0\","
+			+ "\"hwVersion\": \"1.0\",\"descriptiveLocation\": \"EGL C\"    },    "
+			+ "\"location\": {\"measuredDateTime\": \"2015-23-07T11:23:23+00:00\"    "
+			+ "},    \"metadata\": {}}";
+	
+	private final static String deviceToBeAdded2 = "{\"typeId\": \""+ DEVICE_TYPE + "\",\"deviceId\": "
+			+ "\"" + DEVICE_ID2 + "\",\"authToken\": \"password\",\"deviceInfo\": {\"serialNumber\": "
+			+ "\"10087\",\"manufacturer\": \"IBM\",\"model\": \"7865\",\"deviceClass\": "
+			+ "\"A\",\"description\": \"My RasPi01 Device\",\"fwVersion\": \"1.0.0\","
+			+ "\"hwVersion\": \"1.0\",\"descriptiveLocation\": \"EGL C\"    },    "
+			+ "\"location\": {\"measuredDateTime\": \"2015-23-07T11:23:23+00:00\"    "
+			+ "},    \"metadata\": {}}";
+
+
+	private final static String deviceToBeDeleted1 = "{\"typeId\": \""+ DEVICE_TYPE + "\", \"deviceId\": \"" + DEVICE_ID1 + "\"}";
+	private final static String deviceToBeDeleted2 = "{\"typeId\": \"" + DEVICE_TYPE + "\", \"deviceId\": \"" + DEVICE_ID2 + "\"}";
+	private static boolean setUpIsDone = false;
+	
+	private static String EVT_TOPIC = "tempEvent";
+	
+	
+	private static APIClient apiClient = null;
+	private static String physicalSchemaId = null;
+	private static String physicalInterfaceId = null;
+	
+	private static String logicalSchemaId = null;
+	private static String logicalInterfaceId = null;
+	
+	private static String eventId = null;
+	
+	private static String API_KEY = null;
+	
+	/**
+	 * This sample adds a device type using the Java Client Library. 
+	 * @throws IoTFCReSTException
+	 */
+	private void addDeviceType(String deviceType) throws IoTFCReSTException {
+		
+		System.out.println("<-- Checking if device type "+deviceType +" already created in Watson IoT Platform");
+		boolean exist = apiClient.isDeviceTypeExist(deviceType);
+		try {
+			if (!exist) {
+				System.out.println("<-- Adding device type "+deviceType + " now..");
+				// device type to be created in WIoTP
+				apiClient.addDeviceType(deviceType, deviceType, null, null);
+			}
+		} catch(IoTFCReSTException e) {
+			System.err.println("ERROR: unable to add manually device type " + e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * This sample adds a device type using the Java Client Library. 
+	 * @throws IoTFCReSTException
+	 */
+	private void addDevice(String deviceType, String deviceId) throws IoTFCReSTException {
+		
+		System.out.println("<-- Checking if device " + deviceType + " already created in Watson IoT Platform");
+		boolean deviceTypeExist = apiClient.isDeviceTypeExist(deviceType);
+		boolean deviceExist = apiClient.isDeviceExist(deviceType, deviceId);
+		try {
+			if (!deviceTypeExist) {
+				System.out.println("<-- Adding device type " + deviceType + " now..");
+				// device type to be created in WIoTP
+				apiClient.addDeviceType(deviceType, deviceType, null, null);
+			} else {
+				System.out.println("Device Type " + deviceType + " already exists");
+			}
+			if (!deviceTypeExist && !deviceExist) {
+				System.out.println("<-- Adding device " + deviceId + " now..");
+				// device type to be created in WIoTP
+				apiClient.registerDevice(deviceType, deviceId, "password", null, null, null);
+			} else {
+				System.out.println("Device " + deviceId + " already exists");				
+			}
+			
+		} catch(IoTFCReSTException e) {
+			System.err.println("ERROR: unable to add manually device type or device s" + e.getMessage());
+			e.printStackTrace();
+		}
+	}
+	
+	public synchronized void setUp() {
+	    if (setUpIsDone) {
+	        return;
+	    }
+	    
+	    /**
+		  * Load device properties
+		  */
+		Properties props = new Properties();
+		try {
+			props.load(IMOperationsTests.class.getResourceAsStream(PROPERTIES_FILE_NAME));
+		} catch (IOException e1) {
+			System.err.println("Not able to read the properties file, exiting..");
+			System.exit(-1);
+		}	
+		
+		try {
+			//Instantiate the class by passing the properties file
+			this.apiClient = new APIClient(props);
+			addDeviceType(DEVICE_TYPE);
+			addDevice(DEVICE_TYPE, DEVICE_ID1);
+			
+			API_KEY = (String)props.get("API-Key");
+			System.out.println("API KEY = " + API_KEY);
+		} catch (Exception e) {
+			e.printStackTrace();
+			// looks like the application.properties file is not updated properly
+			apiClient = null;
+		}
+	    setUpIsDone = true;
+	}
+		
+	/**
+	 * This sample verifies the Schema addition in Watson IoT
+	 * 
+	 * @throws Exception 
+	 */
+	public void test01AddEventSchema() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+
+		//Create Schema Resource
+		JsonObject draftSchemaResponse = apiClient.addDraftSchemaDefinition(new File(EVENT_SCHEMA1), SCHEMA_NAME1, SCHEMA_DESCRIPTION1, SCHEMA_TYPE1);
+		physicalSchemaId = draftSchemaResponse.get("id").getAsString();
+		System.out.println("Schema created with id = " + physicalSchemaId);
+		System.out.println("Schema Object = " + physicalSchemaId);
+
+		try{
+			Thread.sleep(5000);
+		} catch(InterruptedException iex) {
+			
+		}
+		assertTrue("Schema "+ physicalSchemaId + " got created in the Platform", (physicalSchemaId != null));
+	}
+	
+	
+	public void test02RetrieveSchemaDefinitionContent() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		//Retrieve Schema Content
+		JsonObject draftSchemaResponse = apiClient.getDraftSchemaDefinitionContents(physicalSchemaId);
+		// check if the devices are actually deleted from the platform1
+		System.out.println("Retrieved " );
+		assertTrue("Schema Content of Id = "+ physicalSchemaId + " got retrieved from the Platform", (! draftSchemaResponse.isJsonNull()));
+	}
+	
+	public void test03ModifySchemaDefinitionMetadata() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		
+//		String schemaIdReturned = apiClient.getDraftSchemaDefinitionMetadata(schemaId).get("schemaId").getAsString();
+		JsonObject metadataToBeModified = new JsonObject();
+		metadataToBeModified.addProperty("description", SCHEMA_DESCRIPTION1 + " Modified");
+		metadataToBeModified.addProperty("name", SCHEMA_NAME1 + " new name");
+		metadataToBeModified.addProperty("id", physicalSchemaId);
+//		metadataToBeModified.addProperty("schemaId", schemaIdReturned);
+		
+		JsonObject draftSchemaResponse = apiClient.updateDraftSchemaDefinitionMetadata(physicalSchemaId, metadataToBeModified.toString());
+		assertTrue("Schema Metadata of Id = "+ physicalSchemaId + " got modified from the Platform", (! draftSchemaResponse.isJsonNull()));
+	}
+
+
+	public void test05RetrieveSchemaDefinitionMetadata() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		JsonObject draftSchemaResponse = apiClient.getDraftSchemaDefinitionMetadata(physicalSchemaId);
+		String schemaIdRetrieved = draftSchemaResponse.get("id").getAsString();
+		System.out.println("Retrieved Schema Id from test05 = " + schemaIdRetrieved);
+		assertTrue("Schema Metadata of Id = "+ physicalSchemaId + " got retrieved from the Platform", schemaIdRetrieved.equals(physicalSchemaId));
+	}
+
+	
+	public void test07RetrieveAllDraftSchemas() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+
+		List <NameValuePair> parameters = new ArrayList();
+		NameValuePair nvp = new BasicNameValuePair("_page", "25");
+		parameters.add(nvp);
+		JsonObject draftSchemaResponse = apiClient.getDraftSchemas(parameters);
+		
+		// check if the devices are actually deleted from the platform1
+		try {
+			String noOfRows = draftSchemaResponse.getAsJsonObject("meta").get("total_rows").toString();
+			assertTrue("Schemas retrieved from the Platform = ", noOfRows != null);
+
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			assertFalse("No schemas retrieved from the Platform", true);			
+		}
+	}
+
+	
+	public void test06RetrieveAllActiveSchemas() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		//Retrieve Schema Content
+		List <NameValuePair> parameters = new ArrayList();
+		NameValuePair nvp = new BasicNameValuePair("_page", "25");
+		parameters.add(nvp);
+		JsonObject schemaResponse = apiClient.getActiveSchemas(parameters);
+		
+		// check if the devices are actually deleted from the platform1
+		try {
+			String noOfRows = schemaResponse.getAsJsonObject("meta").get("total_rows").toString();
+			assertTrue("Active Schemas retrieved from the Platform", noOfRows != null);
+
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			assertFalse("Active Schemas retrieved from the Platform", true);
+			
+		}
+	}
+
+	
+	public void test11CreateEventType() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		JsonObject draftEventTypeRequest = new JsonObject();
+
+		Gson gson = new Gson();
+		JsonElement element = gson.fromJson(physicalSchemaId, JsonElement.class);
+				
+		draftEventTypeRequest.add("schemaId", element);
+		draftEventTypeRequest.addProperty("name", EVT_TOPIC);
+		JsonObject draftEventTypeResponse = apiClient.addDraftEventType(draftEventTypeRequest.toString());
+		eventId = draftEventTypeResponse.get("id").getAsString();
+		assertTrue("Event "+ eventId + " got created in the Platform", !(eventId.isEmpty() || eventId == null));
+	}
+
+	
+	public void test12RetrieveSingleEventType() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		JsonObject draftSchemaResponse = apiClient.getDraftEventType(eventId);
+		System.out.println("Retrieved " );
+		assertTrue("Event Type Id = "+ eventId + " got retrieved from the Platform", (! draftSchemaResponse.isJsonNull()));
+		
+	}
+
+	public void test13RetrieveAllEventTypes() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		List <NameValuePair> parameters = new ArrayList();
+		NameValuePair nvp = new BasicNameValuePair("_page", "25");
+		parameters.add(nvp);
+		JsonObject draftEventResponse = apiClient.getDraftEventTypes(parameters);
+		
+		// check if the devices are actually deleted from the platform1
+		try {
+			System.out.println("draftEventResponse = " + draftEventResponse.toString());
+			String noOfRows = draftEventResponse.getAsJsonObject("meta").get("total_rows").toString();
+			assertTrue("Event Types retrieved from the Platform = ", noOfRows != null);
+
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			assertFalse("No event types retrieved from the Platform", true);			
+		}
+	}
+	
+	
+	public void test14UpdateEventType() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		
+		String schemaId = apiClient.getDraftEventType(eventId).get("schemaId").getAsString();
+		
+		JsonObject metadataToBeModified = new JsonObject();
+		metadataToBeModified.addProperty("description", EVENT_DESCRIPTION1 + " Modified");
+		metadataToBeModified.addProperty("name", EVT_TOPIC);
+		metadataToBeModified.addProperty("id", eventId);
+		metadataToBeModified.addProperty("schemaId", schemaId);
+
+		System.out.println("Event Id = " + eventId);
+		JsonObject draftEventResponse = apiClient.updateDraftEventType(eventId, metadataToBeModified.toString());
+		assertTrue("Schema Metadata of Id = "+ schemaId + " got modified from the Platform", (! draftEventResponse.isJsonNull()));
+	}
+	
+	
+	public void test21CreatePhysicalInterface() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		//Create Physical Interfaces
+		JsonObject draftPhysicalInterfaceRequest = new JsonObject();
+		draftPhysicalInterfaceRequest.addProperty("name", "Env sensor physical interface 7");
+		physicalInterfaceId = (apiClient.addDraftPhysicalInterface(draftPhysicalInterfaceRequest.toString()).get("id").getAsString());
+		System.out.println("Draft Physical Interface created with id = " + physicalInterfaceId);
+		try{
+			Thread.sleep(1000);
+		} catch(InterruptedException iex) {
+			iex.printStackTrace();
+		}
+		
+		assertTrue("Physical Interface with Id "+ physicalInterfaceId + " got created in the Platform", !(physicalInterfaceId == null));
+		
+	}
+
+	
+	public void test22RetrieveSingleDraftPhysicalInterface() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		//Retrieve Physical Interfaces
+		JsonObject piReturned = apiClient.getDraftPhysicalInterface(physicalInterfaceId);
+		String piIdReturned = piReturned.get("id").getAsString();
+		assertTrue("Draft Physical Interface Id "+ physicalInterfaceId + " got retrieved from the Platform", piIdReturned.equals(physicalInterfaceId));
+	}
+
+	
+	public void test23RetrieveAllDraftPhysicalInterface() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		//Retrieve Physical Interfaces
+		//Retrieve Schema Content
+		List <NameValuePair> parameters = new ArrayList();
+		NameValuePair nvp = new BasicNameValuePair("_page", "25");
+		parameters.add(nvp);
+		JsonObject draftPIResponse = apiClient.getDraftPhysicalInterfaces(parameters);
+		try {
+			String noOfRows = draftPIResponse.getAsJsonObject("meta").get("total_rows").toString();
+			System.out.println("Physical Interfaces Retrieved " + noOfRows);
+			System.out.println("All Physical Interfaces retrieved = " + draftPIResponse);
+			assertTrue("Number of Physical Interfaces retrieved from the Platform", noOfRows != null);
+
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			assertFalse("No Physical Interfaces retrieved from the Platform", true);
+			
+		}
+		
+	}
+	
+
+	public void test24UpdateDraftPhysicalInterface() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+
+		JsonObject piToBeModified = new JsonObject();
+		piToBeModified.addProperty("description", SCHEMA_DESCRIPTION1 + " Modified");
+		piToBeModified.addProperty("name", "Some Name");
+		piToBeModified.addProperty("id", physicalInterfaceId);
+		JsonObject draftPIResponse = apiClient.updateDraftPhysicalInterface(physicalInterfaceId, piToBeModified.toString());
+		// check if the devices are actually deleted from the platform1
+		assertTrue("Schema Metadata of Id = "+ physicalSchemaId + " got retrieved from the Platform", true);
+	
+	}
+
+	public void test25MapEventToPhysicalInterface() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+
+		try{
+			JsonObject eventTypeToPIRequest = new JsonObject();
+			eventTypeToPIRequest.addProperty("eventId", EVT_TOPIC);
+			eventTypeToPIRequest.addProperty("eventTypeId", eventId);
+			JsonObject eventTypeToPIResponse = apiClient.addEventToPhysicalInterface(physicalInterfaceId, eventTypeToPIRequest.toString());
+			System.out.println("\n4. Event Type to Draft Physical Interface added with eventTypeId = " + eventTypeToPIResponse.get("eventTypeId").getAsString());
+			System.out.println("Event Type to Physical Interface = " + eventTypeToPIResponse.toString());		
+			assertTrue(true);
+		} catch(Exception ex) {
+			ex.printStackTrace();
+			assertFalse(true);
+		}
+	}
+	
+
+	public void test26RetrieveAllMappedEvents() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		
+		List <NameValuePair> parameters = new ArrayList();
+		NameValuePair nvp = new BasicNameValuePair("_page", "25");
+		parameters.add(nvp);
+		JsonArray draftEventMappingsResponse = apiClient.getEventsMappedToDraftPhysicalInterface(physicalInterfaceId);
+		
+		// check if the devices are actually deleted from the platform1
+		try {
+			int noOfRows = draftEventMappingsResponse.size();
+			assertTrue("Event Types retrieved from the Platform = ", noOfRows != 0);
+
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			assertFalse("No schemas retrieved from the Platform", true);			
+		}
+	}
+	
+	public void test31CreateLogicalInterface() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		
+		JsonObject draftLogicalSchemaResponse = apiClient.addDraftSchemaDefinition(new File(EVENT_SCHEMA2), SCHEMA_NAME2, SCHEMA_DESCRIPTION2, SCHEMA_TYPE2);			
+		JsonElement draftLogicalSchemaId = draftLogicalSchemaResponse.get("id");
+		logicalSchemaId = draftLogicalSchemaId.getAsString();
+		
+		//Create Logical Interfaces
+		//Create Draft Logical Interface
+		JsonObject draftLogicalInterfaceRequest = new JsonObject();
+		draftLogicalInterfaceRequest.addProperty("name", "environment sensor interface");
+		draftLogicalInterfaceRequest.addProperty("schemaId", logicalSchemaId);
+		JsonObject draftLogicalInterfaceResponse = apiClient.addDraftLogicalInterface(draftLogicalInterfaceRequest.toString());
+		logicalInterfaceId = draftLogicalInterfaceResponse.get("id").getAsString();
+		System.out.println("Draft Logical Interface created with id = " + logicalInterfaceId);
+		try{
+			Thread.sleep(1000);
+		} catch(InterruptedException iex) {
+			iex.printStackTrace();
+		}
+		
+		assertTrue("Logical Interface with Id "+ logicalInterfaceId + " got created in the Platform", !(logicalInterfaceId == null));
+		
+	}
+
+	public void test32RetrieveSingleDraftLogicalInterface() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		//Retrieve Logical Interfaces
+		JsonObject liReturned = apiClient.getDraftLogicalInterface(logicalInterfaceId);
+		String liIdReturned = liReturned.get("id").getAsString();
+		assertTrue("Draft Logical Interface Id "+ logicalInterfaceId + " got retrieved from the Platform", liIdReturned.equals(logicalInterfaceId));
+	}
+
+	
+	public void test33RetrieveAllDraftLogicalInterface() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		//Retrieve Logical Interfaces
+		//Retrieve Schema Content
+		List <NameValuePair> parameters = new ArrayList();
+		NameValuePair nvp = new BasicNameValuePair("_page", "25");
+		parameters.add(nvp);
+		JsonObject draftLIResponse = apiClient.getDraftLogicalInterfaces(parameters);
+		try {
+			String noOfRows = draftLIResponse.getAsJsonObject("meta").get("total_rows").toString();
+			System.out.println("Retrieved " + noOfRows);
+			assertTrue("Number of Logical Interfaces retrieved from the Platform", noOfRows != null);
+
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			assertFalse("No Logical Interfaces retrieved from the Platform", true);
+			
+		}
+		
+	}
+
+
+	public void test34UpdateDraftLogicalInterface() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+
+		JsonObject liToBeModified = new JsonObject();
+		liToBeModified.addProperty("description", SCHEMA_DESCRIPTION1 + " Modified");
+		liToBeModified.addProperty("name", "Some Name");
+		liToBeModified.add("schemaId", apiClient.getDraftLogicalInterface(logicalInterfaceId).get("schemaId"));
+		liToBeModified.addProperty("id", logicalInterfaceId);
+		JsonObject draftLIResponse = apiClient.updateDraftLogicalInterface(logicalInterfaceId, liToBeModified.toString());
+		// check if the devices are actually deleted from the platform1
+		assertTrue("Schema Metadata of Id = "+ logicalSchemaId + " got retrieved from the Platform", true);
+	
+	}
+	
+	
+	public void test41AssociateDraftLogicalInterfaceToDeviceType() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		JsonObject updateDraftDTToPIRequest = new JsonObject();
+		JsonObject refs = new JsonObject();
+		refs.addProperty("events", "/api/v0002/draft/physicalinterfaces/" + physicalInterfaceId + "/events");
+
+		Gson gson = new Gson();
+		JsonElement element = gson.fromJson(refs.toString(), JsonElement.class);
+
+		updateDraftDTToPIRequest.add("refs", element);
+		updateDraftDTToPIRequest.addProperty("version", "draft");
+		updateDraftDTToPIRequest.addProperty("name", "Env sensor physical interface 1");
+		updateDraftDTToPIRequest.addProperty("createdBy", API_KEY);
+		updateDraftDTToPIRequest.addProperty("updatedBy", API_KEY);
+		updateDraftDTToPIRequest.addProperty("id", physicalInterfaceId);
+		JsonObject updateDraftDTToPIResponse = apiClient.addDraftPhysicalInterfaceToDeviceType(DEVICE_TYPE, updateDraftDTToPIRequest.toString());
+		
+	}
+	
+	public void test90DeleteMapping() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+
+		boolean mappingDeletion = apiClient.deleteEventMappingFromPhysicalInterface(physicalInterfaceId, EVT_TOPIC);
+		assertTrue("Event Type deletion = ", mappingDeletion);
+	}
+
+	
+	public void test91DeleteEventType() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+
+		boolean eventDeletion = apiClient.deleteDraftEventType(eventId);
+		assertTrue("Event Type deletion = ", eventDeletion);
+	}
+	
+	
+	public void test94DeleteDraftPhysicalInterfaceFromDeviceType() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		boolean draftPIFromDeviceType = apiClient.deleteDraftPhysicalInterfaceFromDeviceType(DEVICE_TYPE);
+		assertTrue("Draft Physical Interface deleted from "+ DEVICE_TYPE, draftPIFromDeviceType);		
+	}
+
+
+	public void test95DeleteLogicalInterface() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		//Delete Logical Interfaces
+		boolean liDeletion = apiClient.deleteDraftLogicalInterface(logicalInterfaceId);
+		assertTrue("Logical Interface "+ logicalInterfaceId + " got deleted from the Platform", liDeletion);		
+	}
+
+		
+	public void test96DeletePhysicalInterface() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+		//Delete Physical Interfaces
+		boolean piDeletion = apiClient.deleteDraftPhysicalInterface(physicalInterfaceId);
+		assertTrue("Physical Interface "+ physicalInterfaceId + " got deleted from the Platform", piDeletion);		
+	}
+	
+	
+	public void test99DeleteSchemaDefinitionContent() throws IoTFCReSTException {
+		if(apiClient == null) {
+			return;
+		}
+
+		//Delete Schema Content
+		System.out.println("Schema Id used for deletion" + physicalSchemaId);		
+		boolean physicalSchemaDeletion = apiClient.deleteDraftSchemaDefinition(physicalSchemaId);
+		boolean logicalSchemaDeletion = apiClient.deleteDraftSchemaDefinition(logicalSchemaId);
+
+		// check if the devices are actually deleted from the platform1
+		assertTrue("PhysicalSchema = "+ physicalSchemaId + " and LogicalSchema = " + logicalSchemaId + " got deleted from the Platform", physicalSchemaDeletion && logicalSchemaDeletion);
+		
+	}
+	
+}

--- a/src/test/java/com/ibm/iotf/client/infomgmt/IMOperationsTests.java
+++ b/src/test/java/com/ibm/iotf/client/infomgmt/IMOperationsTests.java
@@ -47,68 +47,22 @@ public class IMOperationsTests extends TestCase {
 	private final static String PROPERTIES_FILE_NAME = "/application.properties";
 	private final static String DEVICE_TYPE = "SampleDT";
 	private final static String DEVICE_ID1 = "Device01";
-	private final static String DEVICE_ID2 = "Device02";
-	
-	private final static String APPLICATION_PROPERTIES_FILE = "/application.properties";
-	
-	private final static String EVENT_SCHEMA1 = "/Users/amitmangalvedkar/Documents/workspace/mars/watsoniot/testlibraries/"
-			+ "iot-sample-java/src/main/resources/tempEventSchema.json";
-	private final static String SCHEMA_NAME1 = "fahrenhietSchema";
-	private final static String SCHEMA_DESCRIPTION1 = "Schema to capture the temperature readings in Fahrenhiet";
-	private final static String SCHEMA_TYPE1 = "json-schema";
-	
-	private final static String EVENT_SCHEMA2 = "/Users/amitmangalvedkar/Documents/workspace/mars/watsoniot/testlibraries/"
-			+ "iot-sample-java/src/main/resources/envSensor.json";
-	private final static String SCHEMA_NAME2 = "celciusSchema";
-	private final static String SCHEMA_DESCRIPTION2 = "Schema to capture the temperature readings in Celcius";
-	private final static String SCHEMA_TYPE2 = "json-schema";
-	
-	private final String EVENT_DESCRIPTION1 = "Native event definition for the MyBulbCo light bulb on event";
-	
-	// Example Json format to add a device
-	/*
-	 * {
-		    "typeId": "SampleDT",
-		    "deviceId": "RasPi100",
-		    "authToken": "password",
-		    "deviceInfo": {
-		        "serialNumber": "10087",
-		        "manufacturer": "IBM",
-		        "model": "7865",
-		        "deviceClass": "A",
-		        "description": "My RasPi01 Device",
-		        "fwVersion": "1.0.0",
-		        "hwVersion": "1.0",
-		        "descriptiveLocation": "EGL C"
-		    },
-		    "location": {
-		        "measuredDateTime": "2015-23-07T11:23:23+00:00"
-		    },
-		    "metadata": {}
-		}
-	 */
-	private final static String deviceToBeAdded1 = "{\"typeId\": \""+ DEVICE_TYPE + "\",\"deviceId\": "
-			+ "\"" + DEVICE_ID1 + "\",\"authToken\": \"password\",\"deviceInfo\": {\"serialNumber\": "
-			+ "\"10087\",\"manufacturer\": \"IBM\",\"model\": \"7865\",\"deviceClass\": "
-			+ "\"A\",\"description\": \"My RasPi01 Device\",\"fwVersion\": \"1.0.0\","
-			+ "\"hwVersion\": \"1.0\",\"descriptiveLocation\": \"EGL C\"    },    "
-			+ "\"location\": {\"measuredDateTime\": \"2015-23-07T11:23:23+00:00\"    "
-			+ "},    \"metadata\": {}}";
-	
-	private final static String deviceToBeAdded2 = "{\"typeId\": \""+ DEVICE_TYPE + "\",\"deviceId\": "
-			+ "\"" + DEVICE_ID2 + "\",\"authToken\": \"password\",\"deviceInfo\": {\"serialNumber\": "
-			+ "\"10087\",\"manufacturer\": \"IBM\",\"model\": \"7865\",\"deviceClass\": "
-			+ "\"A\",\"description\": \"My RasPi01 Device\",\"fwVersion\": \"1.0.0\","
-			+ "\"hwVersion\": \"1.0\",\"descriptiveLocation\": \"EGL C\"    },    "
-			+ "\"location\": {\"measuredDateTime\": \"2015-23-07T11:23:23+00:00\"    "
-			+ "},    \"metadata\": {}}";
 
-
-	private final static String deviceToBeDeleted1 = "{\"typeId\": \""+ DEVICE_TYPE + "\", \"deviceId\": \"" + DEVICE_ID1 + "\"}";
-	private final static String deviceToBeDeleted2 = "{\"typeId\": \"" + DEVICE_TYPE + "\", \"deviceId\": \"" + DEVICE_ID2 + "\"}";
 	private static boolean setUpIsDone = false;
 	
-	private static String EVT_TOPIC = "tempEvent";
+	private static String EVENT_SCHEMA1 = null;
+	private static String SCHEMA_NAME1 = null;
+	private static String SCHEMA_DESCRIPTION1 = null;
+	private static String SCHEMA_TYPE1 = null;
+	
+	private static String EVENT_SCHEMA2 = null;
+	private static String SCHEMA_NAME2 = null;
+	private static String SCHEMA_DESCRIPTION2 = null;
+	private static String SCHEMA_TYPE2 = null;
+	
+	private static String EVENT_DESCRIPTION1 = null;
+
+	private static String EVT_TOPIC = null;
 	
 	
 	private static APIClient apiClient = null;
@@ -119,7 +73,6 @@ public class IMOperationsTests extends TestCase {
 	private static String logicalInterfaceId = null;
 	
 	private static String eventId = null;
-	
 	private static String API_KEY = null;
 	
 	/**
@@ -195,9 +148,35 @@ public class IMOperationsTests extends TestCase {
 			addDeviceType(DEVICE_TYPE);
 			addDevice(DEVICE_TYPE, DEVICE_ID1);
 			
-			API_KEY = (String)props.get("API-Key");
-			System.out.println("API KEY = " + API_KEY);
-		} catch (Exception e) {
+			API_KEY = props.getProperty("API-Key");
+			EVENT_SCHEMA1 = props.getProperty("EVENT_SCHEMA1");
+			EVENT_SCHEMA2 = props.getProperty("EVENT_SCHEMA2");
+			
+			SCHEMA_NAME1 = props.getProperty("SCHEMA_NAME1");
+			SCHEMA_DESCRIPTION1 = props.getProperty("SCHEMA_DESCRIPTION1");
+			SCHEMA_TYPE1 = props.getProperty("SCHEMA_TYPE1");
+			
+			SCHEMA_NAME2 = props.getProperty("SCHEMA_NAME2");
+			SCHEMA_DESCRIPTION2 = props.getProperty("SCHEMA_DESCRIPTION2");
+			SCHEMA_TYPE2 = props.getProperty("SCHEMA_TYPE2");
+			
+			EVENT_DESCRIPTION1 = props.getProperty("EVENT_DESCRIPTION1");
+			EVT_TOPIC = props.getProperty("EVT_TOPIC");
+			
+			System.out.println("API KEY = " + API_KEY + 
+					"\nEVENT_SCHEMA1 = " + EVENT_SCHEMA1 + 
+					"\nEVENT_SCHEMA2 = " + EVENT_SCHEMA2 +
+					
+					"\nSCHEMA_NAME1 = " + SCHEMA_NAME1 + 
+					"\nSCHEMA_DESCRIPTION1 = " + SCHEMA_DESCRIPTION1 +
+					"\nSCHEMA_TYPE1 = " + SCHEMA_TYPE1 +
+					
+					"\nSCHEMA_NAME2 = " + SCHEMA_NAME2 + 
+					"\nSCHEMA_DESCRIPTION2 = " + SCHEMA_DESCRIPTION2 +
+					"\nSCHEMA_TYPE2 = " + SCHEMA_TYPE2 +
+					"\nEVENT_DESCRIPTION1 = " + EVENT_DESCRIPTION1 +
+					"\nEVT_TOPIC = " + EVT_TOPIC);
+		} catch (Exception e) { 
 			e.printStackTrace();
 			// looks like the application.properties file is not updated properly
 			apiClient = null;

--- a/src/test/java/com/ibm/iotf/client/infomgmt/IMOperationsTests.java
+++ b/src/test/java/com/ibm/iotf/client/infomgmt/IMOperationsTests.java
@@ -14,8 +14,13 @@
 
 package com.ibm.iotf.client.infomgmt;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -195,6 +200,18 @@ public class IMOperationsTests extends TestCase {
 		}
 
 		//Create Schema Resource
+		
+		try {
+			BufferedReader br = new BufferedReader(new FileReader(new File(EVENT_SCHEMA1)));
+			String sCurrentLine;
+
+			while ((sCurrentLine = br.readLine()) != null) {
+				System.out.println(sCurrentLine);
+			}
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
 		JsonObject draftSchemaResponse = apiClient.addDraftSchemaDefinition(new File(EVENT_SCHEMA1), SCHEMA_NAME1, SCHEMA_DESCRIPTION1, SCHEMA_TYPE1);
 		physicalSchemaId = draftSchemaResponse.get("id").getAsString();
 		System.out.println("Schema created with id = " + physicalSchemaId);

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,17 +1,34 @@
 ## Mandatory fields
-id = <Unique application id>
-Organization-ID = <Your Organization ID>
+id = app01
+Organization-ID = l3l6wt
 Authentication-Method = apikey
-API-Key = <Your Organization's API Key>
-Authentication-Token = <Your Organization's Token>
+API-Key = a-l3l6wt-kot6eomffc
+Authentication-Token = PKaK6Hso5SR6-GE2sh
+
 
 ## Device on behalf the application needs to subscribe to events or publish events
-Device-Type = <Device-Type>
-Device-ID = <Device-ID>
+Device-Type = deviceType
+Device-ID = device
+
 
 ## Optional fields
-Shared-Subscription = <true or false>
+Shared-Subscription = true
 Clean-Session = true
 WebSocket = false
 Secure = true
 MaxInflightMessages = 100
+
+
+## IM Parameters
+EVENT_SCHEMA1 = /tmp/tempEventSchema.json
+SCHEMA_NAME1 = fahrenhietSchema
+SCHEMA_DESCRIPTION1 = Schema to capture the temperature readings in Fahrenhiet
+SCHEMA_TYPE1 = json-schema
+
+EVENT_SCHEMA2 = /tmp/envSensor.json
+SCHEMA_NAME2 = celciusSchema
+SCHEMA_DESCRIPTION2 = Schema to capture the temperature readings in Celcius
+SCHEMA_TYPE2 = json-schema
+
+EVENT_DESCRIPTION1 = Native event definition for the MyBulbCo light bulb on event
+EVT_TOPIC = tempEvent

--- a/src/test/resources/envSensor.json
+++ b/src/test/resources/envSensor.json
@@ -1,0 +1,15 @@
+{
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "title": "Environment Sensor Schema",
+        "description": "Schema to represent a canonical environment sensor device",
+        "properties": {
+                "temperature": {
+                        "description": "temperature in degrees Celsius",
+                        "type": "number",
+                        "minimum": -273.15,
+                        "default": 0.0
+                }
+        },
+        "required": ["temperature"]
+}

--- a/src/test/resources/tempEventSchema.json
+++ b/src/test/resources/tempEventSchema.json
@@ -1,0 +1,15 @@
+{
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "title": "EnvSensor4 tempEvent Schema",
+        "description": "defines the structure of a temperature event in degrees Fahrenheit ",
+        "properties": {
+                "temp": {
+                        "description": "temperature in degrees Fahrenheit",
+                        "type": "number",
+                        "minimum": -459.67,
+                        "default": 75.0
+                }
+        },
+        "required": ["temp"]
+}


### PR DESCRIPTION
The [IM APIs](https://docs.internetofthings.ibmcloud.com/apis/swagger/v0002/state-mgmt.html) capabilities of IBM® Watson™ IoT Platform help you to organize and integrate data coming in to and going out of Watson IoT Platform. This consists of the following 
1. DeviceTypes
2. Devices
3. EventTypes
4. LogicalInterface
5. PhysicalInterface
6. Schemas