### PR TITLE
Refine 404 exception message for getDevice API

### DIFF
--- a/src/main/java/com/ibm/iotf/client/api/APIClient.java
+++ b/src/main/java/com/ibm/iotf/client/api/APIClient.java
@@ -526,7 +526,7 @@ public class APIClient {
 		} else if(code == 403) {
 			throw new IoTFCReSTException(code, "The authentication method is invalid or the API key used does not exist", jsonResponse);
 		} else if(code == 404) {
-			throw new IoTFCReSTException(code, "The device type does not exist", jsonResponse);
+			throw new IoTFCReSTException(code, "The device type or device does not exist", jsonResponse);
 		} else if (code == 500) {
 			throw new IoTFCReSTException(code, "Unexpected error", jsonResponse);
 		}


### PR DESCRIPTION
This is to resolve issue https://github.com/ibm-watson-iot/iot-java/issues/132 : The 404 exception message for getDevice API is misleading:

When 404 is returned by the getDevice API, the exception message printed by the java client is always HttpCode :404 ErrorMessage :: The device type does not exist even though I am sure the device type does exist and it is the deviceId which I provided in the request actually doesn't exist. For someone who is new to the iot java client, this misleading  exception message may cause confusion and even possibly a support ticket  from customer to our IoT Platform complaining that the REST API isn't  working properly. So it's worthwhile to refine this exception message.